### PR TITLE
fix: remove redundant model binding attributes from Minimal API route…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -122,7 +122,6 @@ charset = utf-8-bom
 
 [*.{cs,vb}]
 
-dotnet_diagnostic.ASP0003.severity = silent
 dotnet_diagnostic.ASP0020.severity = silent
 
 # SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time

--- a/src/Modules/IAM/IAM.Endpoints/Captcha/VersionNeutral/ClientKey/Get/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Captcha/VersionNeutral/ClientKey/Get/Endpoint.cs
@@ -3,7 +3,6 @@ using Common.Domain.ResultMonad;
 using IAM.Application.Captcha.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
 namespace IAM.Endpoints.Captcha.VersionNeutral.ClientKey.Get;
@@ -20,7 +19,7 @@ internal static class Endpoint
             .TransformResultTo<Response>();
     }
 
-    private static Result<Response> GetClientKey([FromServices] ICaptchaService captchaService)
+    private static Result<Response> GetClientKey(ICaptchaService captchaService)
     {
         return Result<string>
             .Success(captchaService.GetClientKey())

--- a/src/Modules/IAM/IAM.Endpoints/Otp/VersionNeutral/Send/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Otp/VersionNeutral/Send/Endpoint.cs
@@ -6,7 +6,6 @@ using IAM.Application.Otp.Services;
 using IAM.Infrastructure.RateLimiting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 
@@ -26,10 +25,10 @@ internal static class Endpoint
     }
 
     private static async Task<Result> SendOtp(
-        [FromBody] Request request,
-        [FromServices] IOtpService otpService,
-        [FromServices] IOptions<OtpOptions> otpOptionsProvider,
-        [FromServices] ICacheService cache,
+        Request request,
+        IOtpService otpService,
+        IOptions<OtpOptions> otpOptionsProvider,
+        ICacheService cache,
         CancellationToken cancellationToken)
     {
         return await Result<string>

--- a/src/Modules/IAM/IAM.Endpoints/Tokens/VersionNeutral/Create/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Tokens/VersionNeutral/Create/Endpoint.cs
@@ -10,7 +10,6 @@ using IAM.Application.Tokens.DTOs;
 using IAM.Application.Tokens.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
 namespace IAM.Endpoints.Tokens.VersionNeutral.Create;
@@ -28,11 +27,11 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> CreateTokens(
-        [FromBody] Request request,
-        [FromServices] IIAMDbContext dbContext,
-        [FromServices] ITokenService tokenService,
-        [FromServices] IOtpService otpService,
-        [FromServices] TimeProvider timeProvider,
+        Request request,
+        IIAMDbContext dbContext,
+        ITokenService tokenService,
+        IOtpService otpService,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         return await otpService

--- a/src/Modules/IAM/IAM.Endpoints/Tokens/VersionNeutral/Refresh/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Tokens/VersionNeutral/Refresh/Endpoint.cs
@@ -9,7 +9,6 @@ using IAM.Application.Tokens.Services;
 using IAM.Domain.Errors;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 
@@ -28,10 +27,10 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> RefreshToken(
-        [FromBody] Request request,
-        [FromServices] IIAMDbContext dbContext,
-        [FromServices] TimeProvider timeProvider,
-        [FromServices] ITokenService tokenService,
+        Request request,
+        IIAMDbContext dbContext,
+        TimeProvider timeProvider,
+        ITokenService tokenService,
         CancellationToken cancellationToken)
     {
         var providedRefreshToken = Convert.FromBase64String(request.RefreshToken);

--- a/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/CheckRegistration/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/CheckRegistration/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Infrastructure.Persistence.Extensions;
 using IAM.Application.Persistence;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
 namespace IAM.Endpoints.Users.VersionNeutral.CheckRegistration;
@@ -23,7 +22,7 @@ internal static class Endpoint
 
     private static async Task<Result<Response>> IsRegisteredAsync(
         [AsParameters] Request request,
-        [FromServices] IIAMDbContext dbContext,
+        IIAMDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/Get/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/Get/Endpoint.cs
@@ -7,7 +7,6 @@ using IAM.Domain.Identity;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
 namespace IAM.Endpoints.Users.VersionNeutral.Get;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result<Response>> GetAsync(
         [AsParameters] Request request,
-        [FromServices] IIAMDbContext dbContext,
+        IIAMDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/Me/Get/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/Me/Get/Endpoint.cs
@@ -6,7 +6,6 @@ using IAM.Application.Persistence;
 using IAM.Domain.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
 namespace IAM.Endpoints.Users.VersionNeutral.Me.Get;
@@ -24,8 +23,8 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> GetMeAsync(
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IIAMDbContext dbContext,
+        ICurrentUser currentUser,
+        IIAMDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/SelfRegister/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/SelfRegister/Endpoint.cs
@@ -8,7 +8,6 @@ using IAM.Domain.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Constants = IAM.Domain.Constants;
 
@@ -27,9 +26,9 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> RegisterAsync(
-        [FromBody] Request request,
-        [FromServices] UserManager<ApplicationUser> userManager,
-        [FromServices] IOtpService otpService,
+        Request request,
+        UserManager<ApplicationUser> userManager,
+        IOtpService otpService,
         CancellationToken cancellationToken)
     {
         return await otpService

--- a/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Activate/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Activate/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.ProductTemplates;
@@ -25,7 +24,7 @@ internal static class Endpoint
 
     private static async Task<Result> ActivateProductTemplateAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Create/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Create/Endpoint.cs
@@ -3,7 +3,6 @@ using Common.Application.Extensions;
 using Common.Domain.ResultMonad;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.ProductTemplates;
@@ -23,8 +22,8 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> CreateProductTemplateAsync(
-        [FromBody] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        Request request,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await Result<ProductTemplate>

--- a/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Deactivate/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Deactivate/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.ProductTemplates;
@@ -25,7 +24,7 @@ internal static class Endpoint
 
     private static async Task<Result> DeactivateProductTemplateAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Get/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Get/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result<Response>> GetProductTemplateAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Search/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/ProductTemplates/v1/Search/Endpoint.cs
@@ -5,7 +5,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result<PaginationResponse<Response>>> SearchProductTemplatesAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Products/v1/EventHistory/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Products/v1/EventHistory/Endpoint.cs
@@ -6,7 +6,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Products;
@@ -27,7 +26,7 @@ internal static class Endpoint
 
     private static async Task<Result<PaginationResponse<EventDto>>> GetProductEventHistoryAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Products/v1/Get/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Products/v1/Get/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result<Response>> GetProductAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Products/v1/My/Get/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Products/v1/My/Get/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Products;
@@ -25,8 +24,8 @@ internal static class Endpoint
 
     private static async Task<Result<Response>> GetMyProductAsync(
         [AsParameters] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Products/v1/My/Search/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Products/v1/My/Search/Endpoint.cs
@@ -5,7 +5,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,8 +25,8 @@ internal static class Endpoint
 
     private static async Task<Result<PaginationResponse<Response>>> SearchMyProductsAsync(
         [AsParameters] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Products/v1/My/Update/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Products/v1/My/Update/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Products;
@@ -25,8 +24,8 @@ internal static class Endpoint
 
     private static async Task<Result> UpdateMyProductAsync(
         [AsParameters] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Products/v1/Search/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Products/v1/Search/Endpoint.cs
@@ -5,7 +5,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result<PaginationResponse<Response>>> SearchStoreProductsAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Products/v1/Update/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Products/v1/Update/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Products;
@@ -25,7 +24,7 @@ internal static class Endpoint
 
     private static async Task<Result> UpdateProductAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/AddProduct/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/AddProduct/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Products;
@@ -27,7 +26,7 @@ internal static class Endpoint
 
     private static async Task<Result<Response>> AddProductAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/Create/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/Create/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -25,8 +24,8 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> CreateStoreAsync(
-        [FromBody] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        Request request,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/EventHistory/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/EventHistory/Endpoint.cs
@@ -6,7 +6,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Stores;
@@ -27,7 +26,7 @@ internal static class Endpoint
 
     private static async Task<Result<PaginationResponse<EventDto>>> GetStoreHistoryAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/Get/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/Get/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result<Response>> GetStoreAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/My/AddProduct/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/My/AddProduct/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Products;
@@ -26,9 +25,9 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> AddProductToMyStoreAsync(
-        [FromBody] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        Request request,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/My/Create/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/My/Create/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -25,9 +24,9 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> CreateMyStoreAsync(
-        [FromBody] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        Request request,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/My/Get/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/My/Get/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -25,8 +24,8 @@ internal static class Endpoint
     }
 
     private static async Task<Result<Response>> GetMyStoreAsync(
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/My/History/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/My/History/Endpoint.cs
@@ -6,7 +6,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -28,8 +27,8 @@ internal static class Endpoint
 
     private static async Task<Result<PaginationResponse<EventDto>>> GetMyStoreHistoryAsync(
         [AsParameters] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/My/RemoveProduct/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/My/RemoveProduct/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,8 +25,8 @@ internal static class Endpoint
 
     private static async Task<Result> RemoveMyProductAsync(
         [AsParameters] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/My/Update/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/My/Update/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Stores;
@@ -24,9 +23,9 @@ internal static class Endpoint
     }
 
     private static async Task<Result> UpdateMyStoreAsync(
-        [FromBody] Request request,
-        [FromServices] ICurrentUser currentUser,
-        [FromServices] IProductsDbContext dbContext,
+        Request request,
+        ICurrentUser currentUser,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/RemoveProduct/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/RemoveProduct/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result> RemoveProductAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/Search/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/Search/Endpoint.cs
@@ -5,7 +5,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Products.Application.Persistence;
@@ -26,7 +25,7 @@ internal static class Endpoint
 
     private static async Task<Result<PaginationResponse<Response>>> SearchStoresAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext

--- a/src/Modules/Products/Products.Endpoints/Stores/v1/Update/Endpoint.cs
+++ b/src/Modules/Products/Products.Endpoints/Stores/v1/Update/Endpoint.cs
@@ -4,7 +4,6 @@ using Common.Domain.ResultMonad;
 using Common.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Products.Application.Persistence;
 using Products.Domain.Stores;
@@ -25,7 +24,7 @@ internal static class Endpoint
 
     private static async Task<Result> UpdateStoreAsync(
         [AsParameters] Request request,
-        [FromServices] IProductsDbContext dbContext,
+        IProductsDbContext dbContext,
         CancellationToken cancellationToken)
     {
         return await dbContext


### PR DESCRIPTION
… handlers

In ASP.NET Core 7+, Minimal API route handler parameters do not require [FromBody] or [FromServices] attributes — complex types are automatically bound from the request body and services are auto-injected from DI.

- Remove [FromBody] from all route handler method parameters (complex types are auto-bound as request body in Minimal APIs)
- Remove [FromServices] from all route handler method parameters (services registered in DI are auto-injected without the attribute)
- Remove the now-unused `using Microsoft.AspNetCore.Mvc` directives from all affected Endpoint.cs files
- Remove the ASP0003 suppression from .editorconfig (no longer needed)

Note: [FromRoute], [FromQuery], [FromBody] on Request record *properties* used with [AsParameters] are intentionally kept — these correctly specify mixed binding sources (route + body) for a single request model.

Fixes #11