### PR TITLE
fix(ci): make integration tests pass without an external broker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,7 @@ Caller injects `IInterModuleRequestClient<GetSeedUserIdsRequest, GetSeedUserIdsR
 - **Factory isolation rule**: use `IClassFixture<TFactory>` when only one test class needs the factory. When multiple test classes share the same factory type, use `ICollectionFixture<TFactory>` + `[Collection("Name")]` — two `IClassFixture<T>` on different classes in the same assembly boot in parallel and corrupt shared global state (Serilog static logger, OTel `ActivitySource`).
 - **With `IClassFixture`: call `factory.CreateClient()` eagerly** in a field initializer or constructor, never lazily inside a test method body. Lazy calls race with other factories' `DisposeAsync()`, which corrupts global static state before `StartServer()` runs. With `ICollectionFixture` the server is already running before any test executes, so calling `CreateClient()` lazily inside each test body is correct and preferred (gives each test a clean client with no cross-test header/cookie state).
 - Modules under test isolated via `TestModuleOverride` env var (set in `IntegrationTestFactory.GetActiveModules()`).
+- **Test config reaches runtime `IOptions`, NOT registration-time reads.** Values set via `AddInMemoryCollection` in `IntegrationTestFactory.ConfigureWebHost` are merged *after* module installers run, so they only affect runtime `IOptions<T>` resolution — they do **not** reach `configuration.Get<T>()` / `GetValue<T>()` calls executed during DI registration (transport selection, conditional `AddHostedService`, etc.). Anything consumed at registration time must travel via `builder.UseSetting(...)` (registration-visible, like `TestModuleOverride`), an environment variable, or JSON — or be re-gated to read `IOptions<T>` at runtime. A test override that "has no effect" is almost always this.
 
 **`IntegrationTestFactory` pattern** — single class (use `IClassFixture`):
 ```csharp
@@ -295,6 +296,7 @@ public class FeatureBTests(MyModuleTestFactory factory) { ... }
 - **No guesswork.** Never fix based on description alone.
 - Write a failing test first (Red). Fix the code. Test must pass (Green).
 - Use OTel Trace IDs to locate the exact failing span when available.
+- **CI-only failures: observe the failing environment before fixing — do not reason from the stack trace and push a guess.** If a test passes locally but fails only in CI, first instrument the failing path to emit the CI environment's real state, then fix from that evidence. For a DB lock/timeout (e.g. Respawn `Timeout during reading attempt`), dump `pg_stat_activity` and `pg_blocking_pids(...)` plus the *effective* option values from inside the catch, throw it in the exception message (xUnit swallows `Console`), and read it from the CI log. Local-green/CI-red means the local box is masking the cause (a running broker, more CPU, or config that only diverges under CI), so local repro will mislead — one instrumented CI run beats three reasoned guesses.
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -258,6 +258,7 @@ Caller injects `IInterModuleRequestClient<GetSeedUserIdsRequest, GetSeedUserIdsR
 - **Factory isolation rule**: use `IClassFixture<TFactory>` when only one test class needs the factory. When multiple test classes share the same factory type, use `ICollectionFixture<TFactory>` + `[Collection("Name")]` — two `IClassFixture<T>` on different classes in the same assembly boot in parallel and corrupt shared global state (Serilog static logger, OTel `ActivitySource`).
 - **With `IClassFixture`: call `factory.CreateClient()` eagerly** in a field initializer or constructor, never lazily inside a test method body. Lazy calls race with other factories' `DisposeAsync()`, which corrupts global static state before `StartServer()` runs. With `ICollectionFixture` the server is already running before any test executes, so calling `CreateClient()` lazily inside each test body is correct and preferred (gives each test a clean client with no cross-test header/cookie state).
 - Modules under test isolated via `TestModuleOverride` env var (set in `IntegrationTestFactory.GetActiveModules()`).
+- **Test config reaches runtime `IOptions`, NOT registration-time reads.** Values set via `AddInMemoryCollection` in `IntegrationTestFactory.ConfigureWebHost` are merged *after* module installers run, so they only affect runtime `IOptions<T>` resolution — they do **not** reach `configuration.Get<T>()` / `GetValue<T>()` calls executed during DI registration (transport selection, conditional `AddHostedService`, etc.). Anything consumed at registration time must travel via `builder.UseSetting(...)` (registration-visible, like `TestModuleOverride`), an environment variable, or JSON — or be re-gated to read `IOptions<T>` at runtime. A test override that "has no effect" is almost always this.
 
 **`IntegrationTestFactory` pattern** — single class (use `IClassFixture`):
 ```csharp
@@ -295,6 +296,7 @@ public class FeatureBTests(MyModuleTestFactory factory) { ... }
 - **No guesswork.** Never fix based on description alone.
 - Write a failing test first (Red). Fix the code. Test must pass (Green).
 - Use OTel Trace IDs to locate the exact failing span when available.
+- **CI-only failures: observe the failing environment before fixing — do not reason from the stack trace and push a guess.** If a test passes locally but fails only in CI, first instrument the failing path to emit the CI environment's real state, then fix from that evidence. For a DB lock/timeout (e.g. Respawn `Timeout during reading attempt`), dump `pg_stat_activity` and `pg_blocking_pids(...)` plus the *effective* option values from inside the catch, throw it in the exception message (xUnit swallows `Console`), and read it from the CI log. Local-green/CI-red means the local box is masking the cause (a running broker, more CPU, or config that only diverges under CI), so local repro will mislead — one instrumented CI run beats three reasoned guesses.
 
 ---
 

--- a/src/Common/Common.Tests/BaseIntegrationTest.cs
+++ b/src/Common/Common.Tests/BaseIntegrationTest.cs
@@ -69,8 +69,78 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
         await using var connection = new NpgsqlConnection(Factory.ConnectionString);
         await connection.OpenAsync();
 
-        await _respawner.ResetAsync(connection);
+        try
+        {
+            await _respawner.ResetAsync(connection);
+        }
+        catch (Exception ex)
+        {
+            // TEMP CI DIAGNOSTIC: Respawn's DELETE times out only on CI. Dump every other backend's
+            // state/wait-event/query plus blocking-lock pairs so we can see exactly what holds the lock.
+            Console.WriteLine($"[RESPAWN-DIAG] ResetAsync failed: {ex.GetType().Name}: {ex.Message}");
+            await DumpDbActivityAsync();
+            throw;
+        }
     }
+
+#pragma warning disable CA1303 // Diagnostic console output; localization not applicable to TEMP CI diagnostics.
+    private async Task DumpDbActivityAsync()
+    {
+        try
+        {
+            await using var diag = new NpgsqlConnection(Factory.ConnectionString);
+            await diag.OpenAsync();
+
+            await using (var cmd = new NpgsqlCommand(
+                """
+                SELECT pid, state, wait_event_type, wait_event,
+                       EXTRACT(EPOCH FROM (now() - query_start))::int AS dur_s,
+                       left(regexp_replace(query, '\s+', ' ', 'g'), 200) AS q
+                FROM pg_stat_activity
+                WHERE datname = current_database() AND pid <> pg_backend_pid()
+                ORDER BY query_start
+                """, diag))
+            {
+                cmd.CommandTimeout = 10;
+                await using var r = await cmd.ExecuteReaderAsync();
+                Console.WriteLine("[RESPAWN-DIAG] pg_stat_activity:");
+                while (await r.ReadAsync())
+                {
+                    Console.WriteLine(
+                        $"  pid={r["pid"]} state={r["state"]} wait={r["wait_event_type"]}/{r["wait_event"]} dur_s={r["dur_s"]} q={r["q"]}");
+                }
+            }
+
+            await using (var cmd = new NpgsqlCommand(
+                """
+                SELECT blocked.pid AS blocked_pid,
+                       left(regexp_replace(blocked.query, '\s+', ' ', 'g'), 120) AS blocked_q,
+                       blocking.pid AS blocking_pid,
+                       blocking.state AS blocking_state,
+                       left(regexp_replace(blocking.query, '\s+', ' ', 'g'), 120) AS blocking_q
+                FROM pg_stat_activity blocked
+                JOIN LATERAL unnest(pg_blocking_pids(blocked.pid)) AS bp(pid) ON true
+                JOIN pg_stat_activity blocking ON blocking.pid = bp.pid
+                """, diag))
+            {
+                cmd.CommandTimeout = 10;
+                await using var r = await cmd.ExecuteReaderAsync();
+                Console.WriteLine("[RESPAWN-DIAG] blocking pairs:");
+                while (await r.ReadAsync())
+                {
+                    Console.WriteLine(
+                        $"  blocked_pid={r["blocked_pid"]} q={r["blocked_q"]} <-- blocking_pid={r["blocking_pid"]} state={r["blocking_state"]} q={r["blocking_q"]}");
+                }
+            }
+        }
+#pragma warning disable CA1031
+        catch (Exception diagEx)
+#pragma warning restore CA1031
+        {
+            Console.WriteLine($"[RESPAWN-DIAG] diagnostic dump failed: {diagEx.Message}");
+        }
+    }
+#pragma warning restore CA1303
 
     public virtual Task DisposeAsync()
     {

--- a/src/Common/Common.Tests/BaseIntegrationTest.cs
+++ b/src/Common/Common.Tests/BaseIntegrationTest.cs
@@ -75,17 +75,18 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
         }
         catch (Exception ex)
         {
-            // TEMP CI DIAGNOSTIC: Respawn's DELETE times out only on CI. Dump every other backend's
-            // state/wait-event/query plus blocking-lock pairs so we can see exactly what holds the lock.
-            Console.WriteLine($"[RESPAWN-DIAG] ResetAsync failed: {ex.GetType().Name}: {ex.Message}");
-            await DumpDbActivityAsync();
-            throw;
+            // TEMP CI DIAGNOSTIC: Respawn's DELETE times out only on CI. xUnit swallows Console output,
+            // so embed the pg activity / blocking-lock dump in the thrown exception message instead.
+            var dump = await DumpDbActivityAsync();
+            throw new InvalidOperationException(
+                $"[RESPAWN-DIAG] ResetAsync failed: {ex.GetType().Name}: {ex.Message}\n{dump}", ex);
         }
     }
 
-#pragma warning disable CA1303 // Diagnostic console output; localization not applicable to TEMP CI diagnostics.
-    private async Task DumpDbActivityAsync()
+#pragma warning disable CA1305 // Invariant formatting irrelevant for TEMP CI diagnostic output.
+    private async Task<string> DumpDbActivityAsync()
     {
+        var sb = new System.Text.StringBuilder();
         try
         {
             await using var diag = new NpgsqlConnection(Factory.ConnectionString);
@@ -103,10 +104,10 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
             {
                 cmd.CommandTimeout = 10;
                 await using var r = await cmd.ExecuteReaderAsync();
-                Console.WriteLine("[RESPAWN-DIAG] pg_stat_activity:");
+                sb.AppendLine("[RESPAWN-DIAG] pg_stat_activity:");
                 while (await r.ReadAsync())
                 {
-                    Console.WriteLine(
+                    sb.AppendLine(
                         $"  pid={r["pid"]} state={r["state"]} wait={r["wait_event_type"]}/{r["wait_event"]} dur_s={r["dur_s"]} q={r["q"]}");
                 }
             }
@@ -125,10 +126,10 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
             {
                 cmd.CommandTimeout = 10;
                 await using var r = await cmd.ExecuteReaderAsync();
-                Console.WriteLine("[RESPAWN-DIAG] blocking pairs:");
+                sb.AppendLine("[RESPAWN-DIAG] blocking pairs:");
                 while (await r.ReadAsync())
                 {
-                    Console.WriteLine(
+                    sb.AppendLine(
                         $"  blocked_pid={r["blocked_pid"]} q={r["blocked_q"]} <-- blocking_pid={r["blocking_pid"]} state={r["blocking_state"]} q={r["blocking_q"]}");
                 }
             }
@@ -137,10 +138,12 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
         catch (Exception diagEx)
 #pragma warning restore CA1031
         {
-            Console.WriteLine($"[RESPAWN-DIAG] diagnostic dump failed: {diagEx.Message}");
+            sb.AppendLine($"[RESPAWN-DIAG] diagnostic dump failed: {diagEx.Message}");
         }
+
+        return sb.ToString();
     }
-#pragma warning restore CA1303
+#pragma warning restore CA1305
 
     public virtual Task DisposeAsync()
     {

--- a/src/Common/Common.Tests/BaseIntegrationTest.cs
+++ b/src/Common/Common.Tests/BaseIntegrationTest.cs
@@ -69,81 +69,8 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
         await using var connection = new NpgsqlConnection(Factory.ConnectionString);
         await connection.OpenAsync();
 
-        try
-        {
-            await _respawner.ResetAsync(connection);
-        }
-        catch (Exception ex)
-        {
-            // TEMP CI DIAGNOSTIC: Respawn's DELETE times out only on CI. xUnit swallows Console output,
-            // so embed the pg activity / blocking-lock dump in the thrown exception message instead.
-            var dump = await DumpDbActivityAsync();
-            throw new InvalidOperationException(
-                $"[RESPAWN-DIAG] ResetAsync failed: {ex.GetType().Name}: {ex.Message}\n{dump}", ex);
-        }
+        await _respawner.ResetAsync(connection);
     }
-
-#pragma warning disable CA1305 // Invariant formatting irrelevant for TEMP CI diagnostic output.
-    private async Task<string> DumpDbActivityAsync()
-    {
-        var sb = new System.Text.StringBuilder();
-        try
-        {
-            await using var diag = new NpgsqlConnection(Factory.ConnectionString);
-            await diag.OpenAsync();
-
-            await using (var cmd = new NpgsqlCommand(
-                """
-                SELECT pid, state, wait_event_type, wait_event,
-                       EXTRACT(EPOCH FROM (now() - query_start))::int AS dur_s,
-                       left(regexp_replace(query, '\s+', ' ', 'g'), 200) AS q
-                FROM pg_stat_activity
-                WHERE datname = current_database() AND pid <> pg_backend_pid()
-                ORDER BY query_start
-                """, diag))
-            {
-                cmd.CommandTimeout = 10;
-                await using var r = await cmd.ExecuteReaderAsync();
-                sb.AppendLine("[RESPAWN-DIAG] pg_stat_activity:");
-                while (await r.ReadAsync())
-                {
-                    sb.AppendLine(
-                        $"  pid={r["pid"]} state={r["state"]} wait={r["wait_event_type"]}/{r["wait_event"]} dur_s={r["dur_s"]} q={r["q"]}");
-                }
-            }
-
-            await using (var cmd = new NpgsqlCommand(
-                """
-                SELECT blocked.pid AS blocked_pid,
-                       left(regexp_replace(blocked.query, '\s+', ' ', 'g'), 120) AS blocked_q,
-                       blocking.pid AS blocking_pid,
-                       blocking.state AS blocking_state,
-                       left(regexp_replace(blocking.query, '\s+', ' ', 'g'), 120) AS blocking_q
-                FROM pg_stat_activity blocked
-                JOIN LATERAL unnest(pg_blocking_pids(blocked.pid)) AS bp(pid) ON true
-                JOIN pg_stat_activity blocking ON blocking.pid = bp.pid
-                """, diag))
-            {
-                cmd.CommandTimeout = 10;
-                await using var r = await cmd.ExecuteReaderAsync();
-                sb.AppendLine("[RESPAWN-DIAG] blocking pairs:");
-                while (await r.ReadAsync())
-                {
-                    sb.AppendLine(
-                        $"  blocked_pid={r["blocked_pid"]} q={r["blocked_q"]} <-- blocking_pid={r["blocking_pid"]} state={r["blocking_state"]} q={r["blocking_q"]}");
-                }
-            }
-        }
-#pragma warning disable CA1031
-        catch (Exception diagEx)
-#pragma warning restore CA1031
-        {
-            sb.AppendLine($"[RESPAWN-DIAG] diagnostic dump failed: {diagEx.Message}");
-        }
-
-        return sb.ToString();
-    }
-#pragma warning restore CA1305
 
     public virtual Task DisposeAsync()
     {

--- a/src/Common/Common.Tests/IntegrationTestFactory.cs
+++ b/src/Common/Common.Tests/IntegrationTestFactory.cs
@@ -67,7 +67,13 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>, IAsyncLife
                 { "CaptchaOptions:BaseUrl", "" },
                 { "HealthCheckOptions:SkipRabbitMqHealthCheck", "true" },
                 { "MassTransitOptions:UseInMemoryTransport", "true" },
-                { "OutboxOptions:IsProcessor", "true" },
+                // Processor OFF for slice tests: the OutboxProcessor BackgroundService opens
+                // "FOR UPDATE" transactions on OutboxMessages every poll. On CPU-starved CI runners
+                // that transaction stays open long enough to block Respawn's between-test DELETE,
+                // which then fails with "Npgsql ... Timeout during reading attempt". Slice tests only
+                // assert the message was written (IsProcessed == false), so the processor must not run.
+                // Outbox.Tests opts back in via its own OutboxTestWebAppFactory (IsProcessor = true).
+                { "OutboxOptions:IsProcessor", "false" },
                 { "OutboxOptions:PollIntervalMs", "500" },
                 { "OutboxOptions:BatchSize", "50" },
                 { "OutboxOptions:MaxRetryCount", "3" },

--- a/src/Common/Common.Tests/IntegrationTestFactory.cs
+++ b/src/Common/Common.Tests/IntegrationTestFactory.cs
@@ -66,6 +66,7 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>, IAsyncLife
                 { "AuditLogOptions:RetentionDays", "90" },
                 { "CaptchaOptions:BaseUrl", "" },
                 { "HealthCheckOptions:SkipRabbitMqHealthCheck", "true" },
+                { "MassTransitOptions:UseInMemoryTransport", "true" },
                 { "OutboxOptions:IsProcessor", "true" },
                 { "OutboxOptions:PollIntervalMs", "500" },
                 { "OutboxOptions:BatchSize", "50" },

--- a/src/Common/Common.Tests/IntegrationTestFactory.cs
+++ b/src/Common/Common.Tests/IntegrationTestFactory.cs
@@ -42,6 +42,12 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>, IAsyncLife
         var overrideModule = string.Join(",", GetActiveModules());
         builder.UseSetting("TestModuleOverride", overrideModule);
 
+        // Transport is chosen at module-registration time, before ConfigureAppConfiguration's in-memory
+        // overrides are merged — so it must travel via UseSetting (which IS visible at registration, like
+        // TestModuleOverride). In-memory transport delivers inter-module request/response in-process so
+        // tests need no RabbitMQ broker. Outbox.Tests overrides this back to RabbitMQ for its own broker.
+        builder.UseSetting("MassTransitOptions:UseInMemoryTransport", "true");
+
         builder.ConfigureAppConfiguration((context, config) =>
         {
             var confDict = new Dictionary<string, string?>
@@ -66,12 +72,12 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>, IAsyncLife
                 { "AuditLogOptions:RetentionDays", "90" },
                 { "CaptchaOptions:BaseUrl", "" },
                 { "HealthCheckOptions:SkipRabbitMqHealthCheck", "true" },
-                { "MassTransitOptions:UseInMemoryTransport", "true" },
                 // Processor OFF for slice tests: the OutboxProcessor BackgroundService opens
                 // "FOR UPDATE" transactions on OutboxMessages every poll. On CPU-starved CI runners
                 // that transaction stays open long enough to block Respawn's between-test DELETE,
                 // which then fails with "Npgsql ... Timeout during reading attempt". Slice tests only
                 // assert the message was written (IsProcessed == false), so the processor must not run.
+                // Read at runtime by OutboxProcessor via IOptions, so this in-memory value applies.
                 // Outbox.Tests opts back in via its own OutboxTestWebAppFactory (IsProcessor = true).
                 { "OutboxOptions:IsProcessor", "false" },
                 { "OutboxOptions:PollIntervalMs", "500" },

--- a/src/Host/Host/Infrastructure/Setup.MassTransit.cs
+++ b/src/Host/Host/Infrastructure/Setup.MassTransit.cs
@@ -14,6 +14,12 @@ internal static partial class Setup
     {
         services.Configure<RabbitMqOptions>(configuration.GetSection(nameof(RabbitMqOptions)));
 
+        // Integration tests run with no RabbitMQ broker. Against a real broker the bus blocks while the
+        // OutboxProcessor publishes inside an open transaction holding "FOR UPDATE" locks on OutboxMessages,
+        // so Respawn's between-test DELETE deadlocks and times out. The in-memory transport delivers in-process,
+        // keeping publish/consume real (no mocking) while removing the broker dependency entirely.
+        var useInMemoryTransport = configuration.GetValue<bool>("MassTransitOptions:UseInMemoryTransport");
+
         services.AddMassTransit(x =>
         {
             x.AddConsumers(moduleAssemblies);
@@ -27,6 +33,12 @@ internal static partial class Setup
                 options.Tags.Clear();
                 options.Tags.Add("masstransit");
             });
+
+            if (useInMemoryTransport)
+            {
+                x.UsingInMemory((ctx, cfg) => cfg.ConfigureEndpoints(ctx));
+                return;
+            }
 
             x.UsingRabbitMq((ctx, cfg) =>
             {

--- a/src/Host/Host/Infrastructure/Setup.MassTransit.cs
+++ b/src/Host/Host/Infrastructure/Setup.MassTransit.cs
@@ -18,6 +18,16 @@ internal static partial class Setup
         {
             x.AddConsumers(moduleAssemblies);
 
+            // MassTransit auto-registers a "masstransit-bus" health check tagged "ready" by default.
+            // Drop the "ready" tag so it cannot gate the readiness probe: broker readiness is owned by
+            // ConditionalRabbitMqHealthCheck (skippable via HealthCheckOptions.SkipRabbitMqHealthCheck),
+            // which keeps test/CI environments — where no broker runs — from failing /health/ready.
+            x.ConfigureHealthCheckOptions(options =>
+            {
+                options.Tags.Clear();
+                options.Tags.Add("masstransit");
+            });
+
             x.UsingRabbitMq((ctx, cfg) =>
             {
                 var opts = ctx.GetRequiredService<IOptions<RabbitMqOptions>>().Value;

--- a/src/Modules/Outbox/Outbox.Tests/OutboxTestWebAppFactory.cs
+++ b/src/Modules/Outbox/Outbox.Tests/OutboxTestWebAppFactory.cs
@@ -18,6 +18,10 @@ public class OutboxTestWebAppFactory : IntegrationTestFactory, IAsyncLifetime
     {
         base.ConfigureWebHost(builder);
 
+        // Outbox.Tests exercises real publishing against its own RabbitMQ container, so override the
+        // base factory's in-memory transport back to RabbitMQ. UseSetting wins (registration-visible).
+        builder.UseSetting("MassTransitOptions:UseInMemoryTransport", "false");
+
         builder.ConfigureAppConfiguration((_, config) =>
         {
             var confDict = new Dictionary<string, string?>

--- a/src/Modules/Outbox/Outbox/OutboxProcessor.cs
+++ b/src/Modules/Outbox/Outbox/OutboxProcessor.cs
@@ -19,6 +19,16 @@ public sealed partial class OutboxProcessor(
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        // Gate at runtime (not registration) so IsProcessor honours the fully-merged configuration,
+        // including overrides supplied by tests. Integration test factories set IsProcessor = false to
+        // keep this BackgroundService from opening "FOR UPDATE" transactions on OutboxMessages that
+        // would otherwise deadlock Respawn's between-test reset. Outbox.Tests opts back in.
+        if (!options.Value.IsProcessor)
+        {
+            LogProcessorDisabled(logger);
+            return;
+        }
+
         LogStarting(logger);
 
         while (!stoppingToken.IsCancellationRequested)
@@ -149,6 +159,10 @@ public sealed partial class OutboxProcessor(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "OutboxProcessor starting.")]
     private static partial void LogStarting(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "OutboxProcessor disabled (IsProcessor = false); not polling on this instance.")]
+    private static partial void LogProcessorDisabled(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Outbox message {MessageId} has null event — skipping.")]
     private static partial void LogNullEvent(ILogger logger, int messageId);


### PR DESCRIPTION
## Problem

The CI/CD `build` job's `make test` step has failed on **every** run. Three test-environment assumptions held only on developer machines (RabbitMQ broker running locally, more CPU) and broke on CI, which provides Postgres via Testcontainers but **no RabbitMQ**.

## Root causes & fixes

**1. `/health/ready` → 503 (Host tests)**
MassTransit auto-registers a `masstransit-bus` health check tagged `ready`; with no broker it's Unhealthy → readiness 503. Dropped the `ready` tag in `Setup.MassTransit` — broker readiness is already owned by the skippable `ConditionalRabbitMqHealthCheck`.

**2. Every IAM/Products/Notifications slice test → `Npgsql ... Timeout during reading attempt` in `Respawn.ResetAsync`**
Diagnosed by dumping `pg_stat_activity` / `pg_blocking_pids` on CI: the `OutboxProcessor` opened a `FOR UPDATE SKIP LOCKED` transaction on `OutboxMessages`, hung mid-publish against the absent broker, and held the lock past Respawn's 30s read timeout.

The reason my first attempts (in-memory transport, `IsProcessor=false` via `AddInMemoryCollection`) had **zero effect**: module installers read config at **DI-registration time**, before `WebApplicationFactory`'s in-memory overrides are merged. So:
- `OutboxProcessor` now gates on `IsProcessor` at **runtime** (`IOptions`, which sees the merged override) → slice-test factories actually disable it.
- The in-memory-transport switch travels via `builder.UseSetting` (registration-visible, like `TestModuleOverride`). Integration tests use the in-memory transport (inter-module request/response in-process); `Outbox.Tests` overrides back to RabbitMQ for its own container.

## Docs
Both pitfalls (CI-only diagnosis; registration-vs-runtime test config) added to `CLAUDE.md` and `GEMINI.md`.

## Verification
CI green on this branch — Common 56, Host 15, IAM 39, Products 91, Outbox 2, Notifications 17, BackgroundJobs 5. Docker `build`/`publish` confirmed locally (456MB image). Deploy/docker-push job is unaffected — it only runs on `release/`/`hotfix/`/dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)