### PR TITLE
chore(deps): update all managed packages to latest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -357,6 +357,9 @@ dotnet_diagnostic.S6667.severity = none
 
 dotnet_diagnostic.S6964.severity = none
 
+# S6672: derived DbContexts intentionally pass ILogger<BaseDbContext> to the base ctor (shared log category).
+dotnet_diagnostic.S6672.severity = none
+
 # IDE0005:
 dotnet_diagnostic.IDE0005.severity = none
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,38 +6,38 @@
   <ItemGroup>
     <PackageVersion Include="Aigamo.ResXGenerator" Version="4.3.0" />
     <!-- Transitive pin: MessagePack <2.5.192 has GHSA-hv8m-jj95-wg3x (high). Pulled via SignalR.StackExchangeRedis. -->
-    <PackageVersion Include="MessagePack" Version="2.5.302" />
-    <PackageVersion Include="MessagePack.Annotations" Version="2.5.302" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePack.Annotations" Version="3.1.7" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="10.0.1" />
-    <PackageVersion Include="Hangfire" Version="1.8.22" />
-    <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.13" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
+    <PackageVersion Include="Hangfire" Version="1.8.23" />
+    <PackageVersion Include="Hangfire.PostgreSql" Version="1.21.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.FeatureManagement" Version="4.5.0" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
     <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.6.0" />
     <PackageVersion Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.6.0" />
     <PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
-    <PackageVersion Include="SharpGrip.FluentValidation.AutoValidation.Endpoints" Version="1.5.0" />
+    <PackageVersion Include="SharpGrip.FluentValidation.AutoValidation.Endpoints" Version="2.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.0.0" />
-    <PackageVersion Include="Testcontainers.Kafka" Version="4.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Kafka" Version="4.12.0" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.analyzers" Version="1.26.0">
+    <PackageVersion Include="xunit.analyzers" Version="1.27.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
@@ -50,34 +50,34 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+    <PackageVersion Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>none</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.17.0.131074">
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>none</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
@@ -88,28 +88,28 @@
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
-    <PackageVersion Include="Elastic.Serilog.Sinks" Version="8.12.0" />
+    <PackageVersion Include="Serilog.Sinks.Seq" Version="9.1.0" />
+    <PackageVersion Include="Elastic.Serilog.Sinks" Version="9.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="3.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.9" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="Asp.Versioning.Http" Version="8.1.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="Asp.Versioning.Http" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageVersion Include="MassTransit" Version="8.4.1" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.4.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
-    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.4.0" />
+    <PackageVersion Include="MassTransit" Version="9.1.2" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="9.1.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.12.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.RabbitMQ" Version="9.0.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
   </ItemGroup>

--- a/src/Common/Common.Tests/IntegrationTestFactory.cs
+++ b/src/Common/Common.Tests/IntegrationTestFactory.cs
@@ -13,8 +13,7 @@ namespace Common.Tests;
 
 public class IntegrationTestFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder()
-        .WithImage("postgres:15-alpine")
+    private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder("postgres:15-alpine")
         .WithDatabase("test_db")
         .WithUsername("postgres")
         .WithPassword("postgres")

--- a/src/Host/Host/Infrastructure/Setup.GlobalExceptionHandlingMiddleware.cs
+++ b/src/Host/Host/Infrastructure/Setup.GlobalExceptionHandlingMiddleware.cs
@@ -9,8 +9,8 @@ internal static partial class Setup
         return services.AddSingleton<GlobalExceptionHandlingMiddleware>();
     }
 
-    private static IApplicationBuilder UseGlobalExceptionHandlingMiddleware(this IApplicationBuilder app)
+    private static void UseGlobalExceptionHandlingMiddleware(this IApplicationBuilder app)
     {
-        return app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
+        app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
     }
 }

--- a/src/Host/Host/Infrastructure/Setup.Logger.cs
+++ b/src/Host/Host/Infrastructure/Setup.Logger.cs
@@ -36,12 +36,12 @@ internal static partial class Setup
         return serilog;
     }
 
-    private static LoggerMinimumLevelConfiguration ParseFrom(this LoggerMinimumLevelConfiguration minLevel,
+    private static void ParseFrom(this LoggerMinimumLevelConfiguration minLevel,
         string level)
     {
-        if (level.IsDebug()) { minLevel.Debug(); return minLevel; }
-        if (level.IsInformation()) { minLevel.Information(); return minLevel; }
-        if (level.IsWarning()) { minLevel.Warning(); return minLevel; }
+        if (level.IsDebug()) { minLevel.Debug(); return; }
+        if (level.IsInformation()) { minLevel.Information(); return; }
+        if (level.IsWarning()) { minLevel.Warning(); return; }
         throw new InvalidOperationException($"Minimum log level {level} is unknown.");
     }
 

--- a/src/Host/Host/Infrastructure/Setup.Observability.cs
+++ b/src/Host/Host/Infrastructure/Setup.Observability.cs
@@ -102,12 +102,12 @@ internal static partial class Setup
         });
     }
 
-    private static OpenTelemetryBuilder ConfigureTracing(
+    private static void ConfigureTracing(
         this OpenTelemetryBuilder builder,
         ObservabilityOptions options,
         IReadOnlyList<IModule> activeModules)
     {
-        return builder.WithTracing(x =>
+        builder.WithTracing(x =>
         {
             x
                 .AddAspNetCoreInstrumentation(cfg =>
@@ -118,7 +118,6 @@ internal static partial class Setup
                 .AddHttpClientInstrumentation()
                 .AddEntityFrameworkCoreInstrumentation(cfg =>
                 {
-                    cfg.SetDbStatementForText = true;
                     cfg.EnrichWithIDbCommand = (activity, command) =>
                     {
                         var sql = command.CommandText?.TrimStart();

--- a/src/Host/Host/Swagger/SwaggerDefaultValues.cs
+++ b/src/Host/Host/Swagger/SwaggerDefaultValues.cs
@@ -11,7 +11,7 @@ internal sealed class SwaggerDefaultValues : IOperationFilter
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
         var apiDescription = context.ApiDescription;
-        operation.Deprecated |= apiDescription.IsDeprecated();
+        operation.Deprecated |= apiDescription.IsDeprecated;
 
         if (operation.Responses != null)
         {

--- a/src/Modules/Outbox/Outbox.Tests/OutboxTestWebAppFactory.cs
+++ b/src/Modules/Outbox/Outbox.Tests/OutboxTestWebAppFactory.cs
@@ -10,8 +10,7 @@ public class OutboxTestWebAppFactory : IntegrationTestFactory, IAsyncLifetime
 {
     protected override string[] GetActiveModules() => ["Outbox", "IAM"];
 
-    private readonly RabbitMqContainer _rabbitMqContainer = new RabbitMqBuilder()
-        .WithImage("rabbitmq:3.13-management-alpine")
+    private readonly RabbitMqContainer _rabbitMqContainer = new RabbitMqBuilder("rabbitmq:3.13-management-alpine")
         .Build();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)


### PR DESCRIPTION
## Goal

Clear **all** remaining Renovate findings — bring every centrally-managed package in `Directory.Packages.props` to its latest stable (latest prerelease for packages already on a beta channel). Covers the rate-limited + major updates still listed in Dependency Dashboard #88.

## Major bumps + migrations applied

| Package | From → To | Code change |
|---------|-----------|-------------|
| MassTransit (+RabbitMQ) | 8.4.1 → 9.1.2 | none (compiles clean; runtime via CI) |
| Asp.Versioning.* | 8.1.1 → 10.0.0 | `ApiDescription.IsDeprecated()` is now an extension **property** — dropped `()` |
| OTel.Instrumentation.EntityFrameworkCore | beta.9 → 1.15.1-beta.1 | `SetDbStatementForText` removed — dropped the line |
| MessagePack (transitive pin) | 2.5.302 → 3.1.7 | — |
| coverlet.collector | 6 → 10 | — |
| SharpGrip.FluentValidation.AutoValidation.Endpoints | 1.5 → 2.0 | none |
| Elastic.Serilog.Sinks | 8 → 9 | none |
| Serilog.Sinks.OpenTelemetry | 3 → 4 | none |
| CodeAnalysis.Analyzers | 3.11 → 5.3 | — |
| Testcontainers.* | 4.0 → 4.12 | parameterless builder ctor obsolete — image moved into ctor |
| SonarAnalyzer.CSharp | 10.17 → 10.27 | see analyzer fallout |

Plus ~30 patch/minor bumps (EF Core 10.0.9, ASP.NET 10.0.9, Serilog 4.3.1, Swashbuckle 10.2.1, Hangfire 1.8.23 / PG 1.21.1, OTel 1.16.0, etc.).

## Deliberate pin

- `Microsoft.CodeAnalysis.Common` / `CSharp` held at **5.0.0**: EFCore.Design's `CodeAnalysis.CSharp.Workspaces 5.0.0` requires `CSharp (= 5.0.0)` exactly (NU1608). Analyzers package itself is on 5.3.0.

## Analyzer fallout (SonarAnalyzer 10.27, warnings-as-errors)

- **S6672** suppressed in `.editorconfig` — derived DbContexts intentionally pass `ILogger<BaseDbContext>` to the base ctor (shared category).
- **S3241** — three `Setup.*` methods returned an unused value → changed to `void`.

## Verification

Local: `dotnet build -c Release` on Host + **all 8 test projects** → **0 warnings, 0 errors**.
Runtime (MassTransit 9, MessagePack 3 + SignalR backplane, OTel) is covered by the integration test suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)