### PR TITLE
Load hardening: pool starvation, transaction leaks, races (12 tasks)

### DIFF
--- a/src/Common/Common.Application/EventBus/IntegrationEventHandlerBase.cs
+++ b/src/Common/Common.Application/EventBus/IntegrationEventHandlerBase.cs
@@ -48,7 +48,16 @@ public abstract partial class IntegrationEventHandlerBase<TEvent>(
                 LogProcessingCompleted(logger, eventType, eventId);
                 return true;
             },
-            options: new FusionCacheEntryOptions { Duration = cachingOptions.Value.IdempotencyKeyDuration },
+            options: new FusionCacheEntryOptions
+            {
+                // L1 bound: duplicates cluster within minutes; keeping every key in process
+                // memory for the full IdempotencyKeyDuration grows unbounded with event volume.
+                Duration = TimeSpan.FromHours(1),
+                // L2 (Redis, when configured) holds the key for the full idempotency window.
+                // Without Redis, the effective idempotency window shrinks to 1h — acceptable
+                // because no-Redis is a single-instance dev/test configuration.
+                DistributedCacheDuration = cachingOptions.Value.IdempotencyKeyDuration,
+            },
             token: cancellationToken);
 
         if (factoryRan)

--- a/src/Common/Common.Application/EventBus/IntegrationEventHandlerBase.cs
+++ b/src/Common/Common.Application/EventBus/IntegrationEventHandlerBase.cs
@@ -52,10 +52,10 @@ public abstract partial class IntegrationEventHandlerBase<TEvent>(
             {
                 // L1 bound: duplicates cluster within minutes; keeping every key in process
                 // memory for the full IdempotencyKeyDuration grows unbounded with event volume.
-                Duration = TimeSpan.FromHours(1),
+                Duration = cachingOptions.Value.IdempotencyL1Duration,
                 // L2 (Redis, when configured) holds the key for the full idempotency window.
-                // Without Redis, the effective idempotency window shrinks to 1h — acceptable
-                // because no-Redis is a single-instance dev/test configuration.
+                // Without Redis, the effective idempotency window shrinks to IdempotencyL1Duration —
+                // acceptable because no-Redis is a single-instance dev/test configuration.
                 DistributedCacheDuration = cachingOptions.Value.IdempotencyKeyDuration,
             },
             token: cancellationToken);

--- a/src/Common/Common.Application/Extensions/HostEnvironmentExtensions.cs
+++ b/src/Common/Common.Application/Extensions/HostEnvironmentExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Common.Application.Extensions;
+
+public static class HostEnvironmentExtensions
+{
+    /// <summary>
+    ///     Registration-time environment check for module <c>AddServices</c> methods, which only receive
+    ///     <see cref="IServiceCollection"/> + <c>IConfiguration</c>. Reads the <see cref="IHostEnvironment"/>
+    ///     instance the host builder registered before modules run — honoring <c>DOTNET_ENVIRONMENT</c>,
+    ///     <c>ASPNETCORE_ENVIRONMENT</c>, and <c>UseEnvironment(...)</c> overrides alike — without building
+    ///     a service provider (forbidden in registration code, see CLAUDE.md §7).
+    /// </summary>
+    public static bool IsProductionEnvironment(this IServiceCollection services)
+        => services.LastOrDefault(descriptor => descriptor.ServiceType == typeof(IHostEnvironment))
+            ?.ImplementationInstance is IHostEnvironment environment
+           && environment.IsEnvironment(Environments.Production);
+}

--- a/src/Common/Common.Application/Options/AuditLogOptions.cs
+++ b/src/Common/Common.Application/Options/AuditLogOptions.cs
@@ -6,7 +6,7 @@ namespace Common.Application.Options;
 public class AuditLogOptions
 {
     public required int RetentionDays { get; set; }
-    public int PurgeBatchSize { get; set; } = 5000;
+    public required int PurgeBatchSize { get; set; }
 }
 
 public class AuditLogOptionsValidator : CustomValidator<AuditLogOptions>

--- a/src/Common/Common.Application/Options/AuditLogOptions.cs
+++ b/src/Common/Common.Application/Options/AuditLogOptions.cs
@@ -6,6 +6,7 @@ namespace Common.Application.Options;
 public class AuditLogOptions
 {
     public required int RetentionDays { get; set; }
+    public int PurgeBatchSize { get; set; } = 5000;
 }
 
 public class AuditLogOptionsValidator : CustomValidator<AuditLogOptions>
@@ -15,5 +16,9 @@ public class AuditLogOptionsValidator : CustomValidator<AuditLogOptions>
         RuleFor(x => x.RetentionDays)
             .GreaterThanOrEqualTo(1)
             .WithMessage("Retention days must be at least 1.");
+
+        RuleFor(x => x.PurgeBatchSize)
+            .GreaterThanOrEqualTo(100)
+            .WithMessage("Purge batch size must be at least 100.");
     }
 }

--- a/src/Common/Common.Application/Options/CachingOptions.cs
+++ b/src/Common/Common.Application/Options/CachingOptions.cs
@@ -11,6 +11,14 @@ public class CachingOptions
     public required TimeSpan IdempotencyKeyDuration { get; set; }
 
     /// <summary>
+    ///     L1 (in-process memory) bound for consumer idempotency keys. Duplicate deliveries cluster
+    ///     within minutes (outbox retries, broker redelivery), so this is kept far shorter than
+    ///     <see cref="IdempotencyKeyDuration"/> (the L2/Redis window) to avoid unbounded memory growth
+    ///     proportional to daily event volume.
+    /// </summary>
+    public required TimeSpan IdempotencyL1Duration { get; set; }
+
+    /// <summary>
     ///     Explicit opt-out for single-instance production deployments. With more than one instance,
     ///     in-memory-only caching breaks OTP verification, consumer idempotency, and SignalR fan-out.
     /// </summary>
@@ -59,6 +67,7 @@ public class CachingOptionsValidator : CustomValidator<CachingOptions>
         });
 
         RuleFor(x => x.IdempotencyKeyDuration).GreaterThan(TimeSpan.Zero);
+        RuleFor(x => x.IdempotencyL1Duration).GreaterThan(TimeSpan.Zero);
     }
 }
 

--- a/src/Common/Common.Application/Options/CachingOptions.cs
+++ b/src/Common/Common.Application/Options/CachingOptions.cs
@@ -9,6 +9,12 @@ public class CachingOptions
     public Redis? Redis { get; set; }
     public required CachingEntryDefaults EntryDefaults { get; set; }
     public required TimeSpan IdempotencyKeyDuration { get; set; }
+
+    /// <summary>
+    ///     Explicit opt-out for single-instance production deployments. With more than one instance,
+    ///     in-memory-only caching breaks OTP verification, consumer idempotency, and SignalR fan-out.
+    /// </summary>
+    public bool AllowInMemoryOnlyInProduction { get; set; }
 }
 
 public class CachingEntryDefaults

--- a/src/Common/Common.Application/Options/CaptchaOptions.cs
+++ b/src/Common/Common.Application/Options/CaptchaOptions.cs
@@ -20,7 +20,13 @@ public class CaptchaOptions
     public double ScoreThreshold { get; init; }
 
     /// <summary>"Dummy" (non-production only) or "ReCaptcha".</summary>
-    public string Provider { get; init; } = "ReCaptcha";
+    public required string Provider { get; init; }
+
+    /// <summary>Per-attempt timeout for the resilient HTTP client calling the captcha provider.</summary>
+    public required int AttemptTimeoutSeconds { get; init; }
+
+    /// <summary>Total timeout across all retry attempts for a single captcha validation call.</summary>
+    public required int TotalRequestTimeoutSeconds { get; init; }
 }
 
 public class CaptchaOptionsValidator : CustomValidator<CaptchaOptions>
@@ -48,5 +54,13 @@ public class CaptchaOptionsValidator : CustomValidator<CaptchaOptions>
         RuleFor(o => o.Provider)
             .Must(p => p is "Dummy" or "ReCaptcha")
             .WithMessage("Provider must be 'Dummy' or 'ReCaptcha'.");
+
+        RuleFor(o => o.AttemptTimeoutSeconds)
+            .GreaterThan(0)
+            .WithMessage("AttemptTimeoutSeconds must be greater than 0.");
+
+        RuleFor(o => o.TotalRequestTimeoutSeconds)
+            .GreaterThanOrEqualTo(o => o.AttemptTimeoutSeconds)
+            .WithMessage("TotalRequestTimeoutSeconds must be greater than or equal to AttemptTimeoutSeconds.");
     }
 }

--- a/src/Common/Common.Application/Options/CaptchaOptions.cs
+++ b/src/Common/Common.Application/Options/CaptchaOptions.cs
@@ -18,6 +18,9 @@ public class CaptchaOptions
     ///     Valid range: 0.0 to 1.0. Defaults to 0.5 if not set or zero.
     /// </summary>
     public double ScoreThreshold { get; init; }
+
+    /// <summary>"Dummy" (non-production only) or "ReCaptcha".</summary>
+    public string Provider { get; init; } = "ReCaptcha";
 }
 
 public class CaptchaOptionsValidator : CustomValidator<CaptchaOptions>
@@ -41,5 +44,9 @@ public class CaptchaOptionsValidator : CustomValidator<CaptchaOptions>
         RuleFor(o => o.SecretKey)
             .NotEmpty()
             .WithMessage("SecretKey must not be empty.");
+
+        RuleFor(o => o.Provider)
+            .Must(p => p is "Dummy" or "ReCaptcha")
+            .WithMessage("Provider must be 'Dummy' or 'ReCaptcha'.");
     }
 }

--- a/src/Common/Common.Application/Options/InterModuleRequestOptions.cs
+++ b/src/Common/Common.Application/Options/InterModuleRequestOptions.cs
@@ -1,0 +1,21 @@
+using Common.Application.Validation;
+using FluentValidation;
+
+namespace Common.Application.Options;
+
+public class InterModuleRequestOptions
+{
+    // Sync request/response inside HTTP request paths — fail fast rather than pinning
+    // the caller for MassTransit's default 30s when the target module is down.
+    public required int TimeoutSeconds { get; set; }
+}
+
+public class InterModuleRequestOptionsValidator : CustomValidator<InterModuleRequestOptions>
+{
+    public InterModuleRequestOptionsValidator()
+    {
+        RuleFor(o => o.TimeoutSeconds)
+            .GreaterThan(0)
+            .WithMessage("TimeoutSeconds must be greater than 0.");
+    }
+}

--- a/src/Common/Common.Application/Options/OutboxOptions.cs
+++ b/src/Common/Common.Application/Options/OutboxOptions.cs
@@ -13,6 +13,11 @@ public class OutboxOptions
     public required int BaseBackoffSeconds { get; set; }
     public required int MaxBackoffSeconds { get; set; }
 
+    // Per-publish cancellation budget and claim-lease duration for the lease-claim pattern —
+    // see the comment above OutboxProcessor.ProcessBatchAsync's claim query for the full rationale.
+    public required int PublishTimeoutMs { get; set; }
+    public required int ClaimLeaseSeconds { get; set; }
+
     public required int LagThresholdMinutes { get; set; }
     public required string MetricsCronSchedule { get; set; }
 
@@ -70,6 +75,14 @@ public class OutboxOptionsValidator : CustomValidator<OutboxOptions>
             .WithMessage("MaxBackoffSeconds must be at least 1.")
             .GreaterThanOrEqualTo(o => o.BaseBackoffSeconds)
             .WithMessage("MaxBackoffSeconds must be >= BaseBackoffSeconds.");
+
+        RuleFor(o => o.PublishTimeoutMs)
+            .GreaterThanOrEqualTo(1000)
+            .WithMessage("PublishTimeoutMs must be at least 1000.");
+
+        RuleFor(o => o.ClaimLeaseSeconds)
+            .GreaterThanOrEqualTo(60)
+            .WithMessage("ClaimLeaseSeconds must be at least 60.");
 
         RuleFor(o => o.LagThresholdMinutes)
             .GreaterThanOrEqualTo(1)

--- a/src/Common/Common.Application/Options/RabbitMqOptions.cs
+++ b/src/Common/Common.Application/Options/RabbitMqOptions.cs
@@ -10,6 +10,14 @@ public class RabbitMqOptions
     public string VirtualHost { get; set; } = "/";
     public required string Username { get; set; }
     public required string Password { get; set; }
+
+    // Transient consumer failures (DB blips, pool timeouts) retry with exponential backoff instead
+    // of faulting straight to the _error queue. Consumers are idempotent (IntegrationEventHandlerBase),
+    // so redelivery is safe.
+    public required int RetryLimit { get; set; }
+    public required int RetryMinIntervalMs { get; set; }
+    public required int RetryMaxIntervalMs { get; set; }
+    public required int RetryIntervalDeltaMs { get; set; }
 }
 
 public class RabbitMqOptionsValidator : CustomValidator<RabbitMqOptions>
@@ -35,5 +43,21 @@ public class RabbitMqOptionsValidator : CustomValidator<RabbitMqOptions>
         RuleFor(o => o.Password)
             .NotEmpty()
             .WithMessage("Password must not be empty.");
+
+        RuleFor(o => o.RetryLimit)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("RetryLimit must be at least 0.");
+
+        RuleFor(o => o.RetryMinIntervalMs)
+            .GreaterThan(0)
+            .WithMessage("RetryMinIntervalMs must be greater than 0.");
+
+        RuleFor(o => o.RetryMaxIntervalMs)
+            .GreaterThanOrEqualTo(o => o.RetryMinIntervalMs)
+            .WithMessage("RetryMaxIntervalMs must be >= RetryMinIntervalMs.");
+
+        RuleFor(o => o.RetryIntervalDeltaMs)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("RetryIntervalDeltaMs must be at least 0.");
     }
 }

--- a/src/Common/Common.Application/Persistence/Outbox/OutboxMessage.cs
+++ b/src/Common/Common.Application/Persistence/Outbox/OutboxMessage.cs
@@ -48,4 +48,9 @@ public class OutboxMessage : IOutboxMessage
     }
 
     public void MarkAsFailed(DateTimeOffset failedOn) => FailedOn = failedOn;
+
+    // Undoes a claim lease (NextRetryAt pushed into the future by the claim query) for a message the
+    // processor never got to attempt this batch — makes it immediately eligible again instead of making
+    // callers wait out the full lease.
+    public void ReleaseClaim() => NextRetryAt = null;
 }

--- a/src/Common/Common.Infrastructure/Caching/Setup.cs
+++ b/src/Common/Common.Infrastructure/Caching/Setup.cs
@@ -18,6 +18,17 @@ public static class Setup
                              ?? throw new InvalidOperationException(
                                  $"Configuration for {nameof(CachingOptions)} is null.");
 
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var isProduction = string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase);
+
+        if (isProduction && !cachingOptions.UseRedis && !cachingOptions.AllowInMemoryOnlyInProduction)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(CachingOptions)}.{nameof(CachingOptions.UseRedis)} is false in Production. " +
+                "Multi-instance deployments require Redis for OTP storage, consumer idempotency, and the FusionCache backplane. " +
+                $"Set {nameof(CachingOptions.AllowInMemoryOnlyInProduction)} = true only for single-instance deployments.");
+        }
+
         var defaults = cachingOptions.EntryDefaults;
         var builder = services
             .AddFusionCache()

--- a/src/Common/Common.Infrastructure/Caching/Setup.cs
+++ b/src/Common/Common.Infrastructure/Caching/Setup.cs
@@ -1,3 +1,4 @@
+using Common.Application.Extensions;
 using Common.Application.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,10 +19,7 @@ public static class Setup
                              ?? throw new InvalidOperationException(
                                  $"Configuration for {nameof(CachingOptions)} is null.");
 
-        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        var isProduction = string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase);
-
-        if (isProduction && !cachingOptions.UseRedis && !cachingOptions.AllowInMemoryOnlyInProduction)
+        if (services.IsProductionEnvironment() && !cachingOptions.UseRedis && !cachingOptions.AllowInMemoryOnlyInProduction)
         {
             throw new InvalidOperationException(
                 $"{nameof(CachingOptions)}.{nameof(CachingOptions.UseRedis)} is false in Production. " +

--- a/src/Common/Common.Infrastructure/Persistence/AuditLog/AuditLogRetentionService.cs
+++ b/src/Common/Common.Infrastructure/Persistence/AuditLog/AuditLogRetentionService.cs
@@ -40,6 +40,7 @@ public sealed partial class AuditLogRetentionService(
             }
         }
 
+        var batchSize = auditLogOptions.Value.PurgeBatchSize;
         var totalDeleted = 0;
         foreach (var schema in schemas)
         {
@@ -48,18 +49,27 @@ public sealed partial class AuditLogRetentionService(
 #pragma warning disable CA2100 // Schema name is from information_schema, not user input
             var deleteQuery = $"""
                 DELETE FROM "{schema}"."AuditLog"
-                WHERE "CreatedOn" < @cutoffDate;
+                WHERE ctid IN (
+                    SELECT ctid FROM "{schema}"."AuditLog"
+                    WHERE "CreatedOn" < @cutoffDate
+                    LIMIT @batchSize
+                );
                 """;
 
-            await using var deleteCmd = new NpgsqlCommand(deleteQuery, connection);
-#pragma warning restore CA2100
-            deleteCmd.Parameters.AddWithValue("@cutoffDate", cutoffDate);
-
-            var deleted = await deleteCmd.ExecuteNonQueryAsync(cancellationToken);
-            totalDeleted += deleted;
-
-            if (deleted > 0)
+            while (!cancellationToken.IsCancellationRequested)
             {
+                await using var deleteCmd = new NpgsqlCommand(deleteQuery, connection);
+#pragma warning restore CA2100
+                deleteCmd.Parameters.AddWithValue("@cutoffDate", cutoffDate);
+                deleteCmd.Parameters.AddWithValue("@batchSize", batchSize);
+
+                var deleted = await deleteCmd.ExecuteNonQueryAsync(cancellationToken);
+                if (deleted == 0)
+                {
+                    break;
+                }
+
+                totalDeleted += deleted;
                 LogSchemaRetention(logger, schema, deleted);
             }
         }

--- a/src/Common/Common.Infrastructure/Persistence/EntityConfigurations/AuditLogEntryConfiguration.cs
+++ b/src/Common/Common.Infrastructure/Persistence/EntityConfigurations/AuditLogEntryConfiguration.cs
@@ -25,6 +25,8 @@ public class AuditLogEntryConfiguration : AuditableEntityConfiguration<AuditLogE
             .IsDescending(false, false, true)
             .HasDatabaseName("IX_AuditLog_AggregateId_AggregateType_CreatedOn");
 
+        builder.HasIndex(entry => entry.CreatedOn);
+
         builder
             .Property(entry => entry.AggregateId)
             .IsRequired();

--- a/src/Common/Common.Infrastructure/Persistence/OutboxSaveHelper.cs
+++ b/src/Common/Common.Infrastructure/Persistence/OutboxSaveHelper.cs
@@ -88,7 +88,13 @@ public static partial class OutboxSaveHelper
 
         var integrationEvents = integrationEventOutbox.Drain();
 
-        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        // If the caller already opened a transaction (e.g. an endpoint composing multiple
+        // Identity/DbContext operations into one atomic unit), participate in it instead of
+        // nesting — only the owner commits/rolls back.
+        var ownsTransaction = context.Database.CurrentTransaction is null;
+        await using var transaction = ownsTransaction
+            ? await context.Database.BeginTransactionAsync(cancellationToken)
+            : null;
         try
         {
             var result = await baseSaveAsync(cancellationToken);
@@ -133,11 +139,16 @@ public static partial class OutboxSaveHelper
 #pragma warning restore S3265
             }
 
-            await transaction.CommitAsync(cancellationToken);
+            if (ownsTransaction)
+            {
+                await transaction!.CommitAsync(cancellationToken);
+            }
 
-            // Only clear events once the transaction has actually committed — a failed save
-            // must leave events on the aggregates so a retry on the same context can rebuild
-            // audit + outbox from them.
+            // Clear events once this save is durably committed. When we own the transaction,
+            // that's after our own CommitAsync. When an outer caller owns the transaction, our
+            // part of the work (base save + outbox insert) has still succeeded without error —
+            // if the outer transaction later rolls back, the DB rows disappear along with this
+            // request scope's aggregate instances, so clearing in-memory events here is safe.
             foreach (var entry in aggregatesWithEvents)
             {
                 entry.Entity.ClearEvents();
@@ -147,16 +158,21 @@ public static partial class OutboxSaveHelper
         }
         catch (Exception ex)
         {
-            // Use CancellationToken.None — cancelled request must still rollback.
-            // Wrap so a broken/already-aborted transaction doesn't mask the original error.
-            try
+            if (ownsTransaction)
             {
-                await transaction.RollbackAsync(CancellationToken.None);
+                // Use CancellationToken.None — cancelled request must still rollback.
+                // Wrap so a broken/already-aborted transaction doesn't mask the original error.
+                try
+                {
+                    await transaction!.RollbackAsync(CancellationToken.None);
+                }
+                catch (Exception rollbackEx)
+                {
+                    LogRollbackError(logger, rollbackEx);
+                }
             }
-            catch (Exception rollbackEx)
-            {
-                LogRollbackError(logger, rollbackEx);
-            }
+            // When we don't own the transaction, the outer owner is responsible for rolling back —
+            // we just propagate the exception below.
 
             // Undo this attempt's bookkeeping so a retry of SaveChangesAsync on the same scope
             // rebuilds audit + outbox from the (still-present) aggregate events instead of

--- a/src/Common/Common.Infrastructure/Persistence/OutboxSaveHelper.cs
+++ b/src/Common/Common.Infrastructure/Persistence/OutboxSaveHelper.cs
@@ -65,8 +65,6 @@ public static partial class OutboxSaveHelper
                 auditLogEntries.Add(auditLogEntry);
                 domainEvents.Add(domainEvent);
             }
-
-            aggregateRoot.ClearEvents();
         }
 
         foreach (var entry in auditLogEntries)
@@ -136,6 +134,15 @@ public static partial class OutboxSaveHelper
             }
 
             await transaction.CommitAsync(cancellationToken);
+
+            // Only clear events once the transaction has actually committed — a failed save
+            // must leave events on the aggregates so a retry on the same context can rebuild
+            // audit + outbox from them.
+            foreach (var entry in aggregatesWithEvents)
+            {
+                entry.Entity.ClearEvents();
+            }
+
             return result;
         }
         catch (Exception ex)
@@ -150,6 +157,16 @@ public static partial class OutboxSaveHelper
             {
                 LogRollbackError(logger, rollbackEx);
             }
+
+            // Undo this attempt's bookkeeping so a retry of SaveChangesAsync on the same scope
+            // rebuilds audit + outbox from the (still-present) aggregate events instead of
+            // silently saving entities without them. The drained `integrationEvents` list is
+            // intentionally discarded — re-dispatch on retry regenerates them via DispatchAsync.
+            foreach (var auditEntry in auditLogEntries)
+            {
+                context.Entry(auditEntry).State = EntityState.Detached;
+            }
+
             LogSavingError(logger, ex);
             throw;
         }

--- a/src/Common/Common.InterModuleRequests/Contracts/MassTransitInterModuleRequestClient.cs
+++ b/src/Common/Common.InterModuleRequests/Contracts/MassTransitInterModuleRequestClient.cs
@@ -1,19 +1,20 @@
+using Common.Application.Options;
 using MassTransit;
+using Microsoft.Extensions.Options;
 
 namespace Common.InterModuleRequests.Contracts;
 
-public class MassTransitInterModuleRequestClient<TRequest, TResponse>(IClientFactory clientFactory)
+public class MassTransitInterModuleRequestClient<TRequest, TResponse>(
+    IClientFactory clientFactory,
+    IOptions<InterModuleRequestOptions> options)
     : IInterModuleRequestClient<TRequest, TResponse>
     where TRequest : class, IInterModuleRequest<TResponse>
     where TResponse : class
 {
-    // Sync request/response inside HTTP request paths — fail fast rather than pinning
-    // the caller for MassTransit's default 30s when the target module is down.
-    private static readonly RequestTimeout Timeout = RequestTimeout.After(s: 10);
-
     public async Task<TResponse> SendAsync(TRequest request, CancellationToken cancellationToken)
     {
-        var requestClient = clientFactory.CreateRequestClient<TRequest>(Timeout);
+        var timeout = RequestTimeout.After(s: options.Value.TimeoutSeconds);
+        var requestClient = clientFactory.CreateRequestClient<TRequest>(timeout);
         var response = await requestClient.GetResponse<TResponse>(request, cancellationToken);
         return response.Message;
     }

--- a/src/Common/Common.InterModuleRequests/Contracts/MassTransitInterModuleRequestClient.cs
+++ b/src/Common/Common.InterModuleRequests/Contracts/MassTransitInterModuleRequestClient.cs
@@ -7,9 +7,13 @@ public class MassTransitInterModuleRequestClient<TRequest, TResponse>(IClientFac
     where TRequest : class, IInterModuleRequest<TResponse>
     where TResponse : class
 {
+    // Sync request/response inside HTTP request paths — fail fast rather than pinning
+    // the caller for MassTransit's default 30s when the target module is down.
+    private static readonly RequestTimeout Timeout = RequestTimeout.After(s: 10);
+
     public async Task<TResponse> SendAsync(TRequest request, CancellationToken cancellationToken)
     {
-        var requestClient = clientFactory.CreateRequestClient<TRequest>();
+        var requestClient = clientFactory.CreateRequestClient<TRequest>(Timeout);
         var response = await requestClient.GetResponse<TResponse>(request, cancellationToken);
         return response.Message;
     }

--- a/src/Common/Common.Tests/AuditLogRetentionServiceTests.cs
+++ b/src/Common/Common.Tests/AuditLogRetentionServiceTests.cs
@@ -1,0 +1,78 @@
+using Common.Application.Options;
+using Common.Infrastructure.Persistence.AuditLog;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using Xunit;
+
+namespace Common.Tests;
+
+#pragma warning disable CA1707 // Remove the underscores from member name
+public class AuditLogRetentionServiceTests(IntegrationTestFactory factory) : BaseIntegrationTest(factory)
+{
+    private const string Schema = "IAM";
+
+    [Fact]
+    public async Task PurgeExpiredEntries_MoreRowsThanBatchSize_DeletesAllExpiredKeepsRecent()
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-90);
+        await SeedRowsAsync(count: 12, createdOn: cutoff.AddDays(-1));
+        await SeedRowsAsync(count: 3, createdOn: cutoff.AddDays(1));
+
+        // Batch size (5) smaller than the expired row count (12) forces the purge loop to iterate
+        // more than once, proving it doesn't stop after a single DELETE.
+        var service = CreateService(purgeBatchSize: 5);
+        await service.PurgeExpiredEntriesAsync();
+
+        Assert.Equal(3, await CountRowsAsync());
+    }
+
+    [Fact]
+    public async Task PurgeExpiredEntries_NoExpiredRows_DeletesNothing()
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-90);
+        await SeedRowsAsync(count: 3, createdOn: cutoff.AddDays(1));
+
+        var service = CreateService(purgeBatchSize: 5);
+        await service.PurgeExpiredEntriesAsync();
+
+        Assert.Equal(3, await CountRowsAsync());
+    }
+
+    private AuditLogRetentionService CreateService(int purgeBatchSize)
+    {
+        var dataSource = Scope.ServiceProvider.GetRequiredService<NpgsqlDataSource>();
+        var options = Options.Create(new AuditLogOptions { RetentionDays = 90, PurgeBatchSize = purgeBatchSize });
+        return new AuditLogRetentionService(dataSource, options, NullLogger<AuditLogRetentionService>.Instance);
+    }
+
+    private async Task SeedRowsAsync(int count, DateTimeOffset createdOn)
+    {
+        await using var connection = new NpgsqlConnection(Factory.ConnectionString);
+        await connection.OpenAsync();
+
+        const string sql = $$"""
+            INSERT INTO "{{Schema}}"."AuditLog" ("AggregateId", "AggregateType", "Version", "EventType", "Event", "CreatedOn")
+            VALUES (@aggregateId, 'TestAggregate', 1, 'TestEvent', '{}'::jsonb, @createdOn);
+            """;
+
+        for (var i = 0; i < count; i++)
+        {
+            await using var cmd = new NpgsqlCommand(sql, connection);
+            cmd.Parameters.AddWithValue("@aggregateId", Guid.NewGuid());
+            cmd.Parameters.AddWithValue("@createdOn", createdOn);
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task<long> CountRowsAsync()
+    {
+        await using var connection = new NpgsqlConnection(Factory.ConnectionString);
+        await connection.OpenAsync();
+
+        await using var cmd = new NpgsqlCommand($"""SELECT COUNT(*) FROM "{Schema}"."AuditLog";""", connection);
+        return (long)(await cmd.ExecuteScalarAsync())!;
+    }
+}
+#pragma warning restore CA1707

--- a/src/Common/Common.Tests/CachingSetupTests.cs
+++ b/src/Common/Common.Tests/CachingSetupTests.cs
@@ -21,6 +21,7 @@ public sealed class CachingSetupTests
                 ["CachingOptions:EntryDefaults:FactorySoftTimeout"] = "00:00:00.1",
                 ["CachingOptions:EntryDefaults:FactoryHardTimeout"] = "00:00:01.5",
                 ["CachingOptions:IdempotencyKeyDuration"] = "1.00:00:00",
+                ["CachingOptions:IdempotencyL1Duration"] = "01:00:00",
             })
             .Build();
 

--- a/src/Common/Common.Tests/CachingSetupTests.cs
+++ b/src/Common/Common.Tests/CachingSetupTests.cs
@@ -1,0 +1,81 @@
+#pragma warning disable CA1707 // Remove the underscores from member name
+
+using Common.Infrastructure.Caching;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Common.Tests;
+
+public sealed class CachingSetupTests
+{
+    private static IConfiguration BuildConfiguration(bool useRedis, bool allowInMemoryOnlyInProduction) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CachingOptions:UseRedis"] = useRedis.ToString(),
+                ["CachingOptions:AllowInMemoryOnlyInProduction"] = allowInMemoryOnlyInProduction.ToString(),
+                ["CachingOptions:EntryDefaults:Duration"] = "00:05:00",
+                ["CachingOptions:EntryDefaults:FailSafeMaxDuration"] = "02:00:00",
+                ["CachingOptions:EntryDefaults:FailSafeThrottleDuration"] = "00:00:30",
+                ["CachingOptions:EntryDefaults:FactorySoftTimeout"] = "00:00:00.1",
+                ["CachingOptions:EntryDefaults:FactoryHardTimeout"] = "00:00:01.5",
+                ["CachingOptions:IdempotencyKeyDuration"] = "1.00:00:00",
+            })
+            .Build();
+
+    private static void WithEnvironment(string? environment, Action action)
+    {
+        var original = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
+            action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", original);
+        }
+    }
+
+    [Fact]
+    public void AddCommonCaching_ProductionWithoutRedis_Throws()
+    {
+        WithEnvironment("Production", () =>
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: false);
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => services.AddCommonCaching(configuration));
+
+            Assert.Contains("UseRedis", exception.Message, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void AddCommonCaching_ProductionWithoutRedisButAllowed_DoesNotThrow()
+    {
+        WithEnvironment("Production", () =>
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: true);
+
+            services.AddCommonCaching(configuration);
+        });
+    }
+
+    [Fact]
+    public void AddCommonCaching_DevelopmentWithoutRedis_DoesNotThrow()
+    {
+        WithEnvironment("Development", () =>
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: false);
+
+            services.AddCommonCaching(configuration);
+        });
+    }
+}
+
+#pragma warning restore CA1707

--- a/src/Common/Common.Tests/CachingSetupTests.cs
+++ b/src/Common/Common.Tests/CachingSetupTests.cs
@@ -3,6 +3,7 @@
 using Common.Infrastructure.Caching;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Common.Tests;
@@ -25,57 +26,41 @@ public sealed class CachingSetupTests
             })
             .Build();
 
-    private static void WithEnvironment(string? environment, Action action)
+    private static ServiceCollection BuildServices(string environmentName)
     {
-        var original = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        try
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
-            action();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", original);
-        }
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment(environmentName));
+        return services;
     }
 
     [Fact]
     public void AddCommonCaching_ProductionWithoutRedis_Throws()
     {
-        WithEnvironment("Production", () =>
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: false);
+        var services = BuildServices(Environments.Production);
+        var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: false);
 
-            var exception = Assert.Throws<InvalidOperationException>(
-                () => services.AddCommonCaching(configuration));
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddCommonCaching(configuration));
 
-            Assert.Contains("UseRedis", exception.Message, StringComparison.Ordinal);
-        });
+        Assert.Contains("UseRedis", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void AddCommonCaching_ProductionWithoutRedisButAllowed_DoesNotThrow()
     {
-        WithEnvironment("Production", () =>
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: true);
+        var services = BuildServices(Environments.Production);
+        var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: true);
 
-            services.AddCommonCaching(configuration);
-        });
+        services.AddCommonCaching(configuration);
     }
 
     [Fact]
     public void AddCommonCaching_DevelopmentWithoutRedis_DoesNotThrow()
     {
-        WithEnvironment("Development", () =>
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: false);
+        var services = BuildServices(Environments.Development);
+        var configuration = BuildConfiguration(useRedis: false, allowInMemoryOnlyInProduction: false);
 
-            services.AddCommonCaching(configuration);
-        });
+        services.AddCommonCaching(configuration);
     }
 }
 

--- a/src/Common/Common.Tests/FakeHostEnvironment.cs
+++ b/src/Common/Common.Tests/FakeHostEnvironment.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace Common.Tests;
+
+/// <summary>
+///     Registered into a plain <see cref="Microsoft.Extensions.DependencyInjection.ServiceCollection"/> by
+///     unit tests exercising registration-time Production guards (which resolve the environment via the
+///     <see cref="IHostEnvironment"/> descriptor). Injecting this instead of mutating the process-wide
+///     ASPNETCORE_ENVIRONMENT variable keeps those tests safe to run in parallel with integration-test
+///     factory boots in the same assembly.
+/// </summary>
+public sealed class FakeHostEnvironment(string environmentName) : IHostEnvironment
+{
+    public string EnvironmentName { get; set; } = environmentName;
+    public string ApplicationName { get; set; } = "Tests";
+    public string ContentRootPath { get; set; } = string.Empty;
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+}

--- a/src/Common/Common.Tests/IntegrationTestFactory.cs
+++ b/src/Common/Common.Tests/IntegrationTestFactory.cs
@@ -63,6 +63,9 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>, IAsyncLife
                 { "CustomRateLimitingOptions:TokenRefresh:Limit", "5000" },
                 { "CustomRateLimitingOptions:TokenRefresh:PeriodInMs", "60000" },
                 { "CustomRateLimitingOptions:TokenRefresh:QueueLimit", "1000" },
+                { "CustomRateLimitingOptions:Register:Limit", "5000" },
+                { "CustomRateLimitingOptions:Register:PeriodInMs", "60000" },
+                { "CustomRateLimitingOptions:Register:QueueLimit", "1000" },
                 { "AuditLogOptions:RetentionDays", "90" },
                 { "CaptchaOptions:BaseUrl", "" },
                 // Processor OFF for slice tests: the OutboxProcessor BackgroundService opens

--- a/src/Common/Common.Tests/OutboxMessageTests.cs
+++ b/src/Common/Common.Tests/OutboxMessageTests.cs
@@ -98,4 +98,16 @@ public sealed class OutboxMessageTests
         Assert.True(message.IsProcessed);
         Assert.Equal(processedAt, message.ProcessedOn);
     }
+
+    [Fact]
+    public void ReleaseClaim_Always_ClearsNextRetryAt()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var message = OutboxMessage.Create(now, new TestableIntegrationEvent("x"));
+        message.IncrementRetryCount(now, TimeSpan.FromSeconds(30)); // sets NextRetryAt
+
+        message.ReleaseClaim();
+
+        Assert.Null(message.NextRetryAt);
+    }
 }

--- a/src/Common/Common.Tests/OutboxOptionsValidatorTests.cs
+++ b/src/Common/Common.Tests/OutboxOptionsValidatorTests.cs
@@ -15,6 +15,8 @@ public sealed class OutboxOptionsValidatorTests
         IsProcessor = true,
         BaseBackoffSeconds = 5,
         MaxBackoffSeconds = 600,
+        PublishTimeoutMs = 5000,
+        ClaimLeaseSeconds = 120,
         LagThresholdMinutes = 5,
         MetricsCronSchedule = "*/5 * * * *"
     };
@@ -123,6 +125,30 @@ public sealed class OutboxOptionsValidatorTests
 
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, e => e.PropertyName == nameof(OutboxOptions.MaxBackoffSeconds));
+    }
+
+    [Fact]
+    public void PublishTimeoutMs_BelowMinimum_Fails()
+    {
+        var options = ValidOptions();
+        options.PublishTimeoutMs = 999;
+        var validator = new OutboxOptionsValidator();
+        var result = validator.Validate(options);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.PropertyName == nameof(OutboxOptions.PublishTimeoutMs));
+    }
+
+    [Fact]
+    public void ClaimLeaseSeconds_BelowMinimum_Fails()
+    {
+        var options = ValidOptions();
+        options.ClaimLeaseSeconds = 59;
+        var validator = new OutboxOptionsValidator();
+        var result = validator.Validate(options);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.PropertyName == nameof(OutboxOptions.ClaimLeaseSeconds));
     }
 
     [Fact]

--- a/src/Host/Host/Configurations/Setup.cs
+++ b/src/Host/Host/Configurations/Setup.cs
@@ -17,6 +17,7 @@ internal static class Setup
         AddJsonFile(configuration, $"{configurationsDirectory}/rateLimiting");
         AddJsonFile(configuration, $"{configurationsDirectory}/openApi");
         AddJsonFile(configuration, $"{configurationsDirectory}/eventBus");
+        AddJsonFile(configuration, $"{configurationsDirectory}/interModuleRequest");
         AddJsonFile(configuration, $"{configurationsDirectory}/outbox");
         AddJsonFile(configuration, $"{configurationsDirectory}/backgroundJobs");
         AddJsonFile(configuration, $"{configurationsDirectory}/caching");

--- a/src/Host/Host/Configurations/auditLog.json
+++ b/src/Host/Host/Configurations/auditLog.json
@@ -1,5 +1,6 @@
 {
   "AuditLogOptions": {
-    "RetentionDays": 90
+    "RetentionDays": 90,
+    "PurgeBatchSize": 5000
   }
 }

--- a/src/Host/Host/Configurations/caching.json
+++ b/src/Host/Host/Configurations/caching.json
@@ -12,7 +12,7 @@
       "FailSafeMaxDuration": "02:00:00",
       "FailSafeThrottleDuration": "00:00:30",
       "FactorySoftTimeout": "00:00:00.1",
-      "FactoryHardTimeout": "00:00:01.5"
+      "FactoryHardTimeout": "00:00:30"
     },
     "IdempotencyKeyDuration": "1.00:00:00"
   }

--- a/src/Host/Host/Configurations/caching.json
+++ b/src/Host/Host/Configurations/caching.json
@@ -14,6 +14,7 @@
       "FactorySoftTimeout": "00:00:00.1",
       "FactoryHardTimeout": "00:00:30"
     },
-    "IdempotencyKeyDuration": "1.00:00:00"
+    "IdempotencyKeyDuration": "1.00:00:00",
+    "IdempotencyL1Duration": "01:00:00"
   }
 }

--- a/src/Host/Host/Configurations/captcha.json
+++ b/src/Host/Host/Configurations/captcha.json
@@ -1,5 +1,6 @@
 {
   "CaptchaOptions": {
+    "Provider": "Dummy",
     "BaseUrl": "https://www.google.com/recaptcha/api",
     "CaptchaEndpoint": "siteverify",
     "ClientKey": "myClientKey",

--- a/src/Host/Host/Configurations/captcha.json
+++ b/src/Host/Host/Configurations/captcha.json
@@ -4,6 +4,8 @@
     "BaseUrl": "https://www.google.com/recaptcha/api",
     "CaptchaEndpoint": "siteverify",
     "ClientKey": "myClientKey",
-    "SecretKey": "mySecretKey"
+    "SecretKey": "mySecretKey",
+    "AttemptTimeoutSeconds": 5,
+    "TotalRequestTimeoutSeconds": 15
   }
 }

--- a/src/Host/Host/Configurations/eventBus.json
+++ b/src/Host/Host/Configurations/eventBus.json
@@ -4,6 +4,10 @@
     "Port": 5672,
     "VirtualHost": "/",
     "Username": "guest",
-    "Password": "guest"
+    "Password": "guest",
+    "RetryLimit": 5,
+    "RetryMinIntervalMs": 1000,
+    "RetryMaxIntervalMs": 120000,
+    "RetryIntervalDeltaMs": 5000
   }
 }

--- a/src/Host/Host/Configurations/interModuleRequest.json
+++ b/src/Host/Host/Configurations/interModuleRequest.json
@@ -1,0 +1,5 @@
+{
+  "InterModuleRequestOptions": {
+    "TimeoutSeconds": 10
+  }
+}

--- a/src/Host/Host/Configurations/outbox.json
+++ b/src/Host/Host/Configurations/outbox.json
@@ -6,6 +6,8 @@
     "MaxRetryCount": 5,
     "BaseBackoffSeconds": 5,
     "MaxBackoffSeconds": 600,
+    "PublishTimeoutMs": 5000,
+    "ClaimLeaseSeconds": 120,
     "LagThresholdMinutes": 5,
     "MetricsCronSchedule": "*/5 * * * *",
     "Cleanup": {

--- a/src/Host/Host/Infrastructure/Setup.MassTransit.cs
+++ b/src/Host/Host/Infrastructure/Setup.MassTransit.cs
@@ -56,10 +56,10 @@ internal static partial class Setup
                 // faulting straight to the _error queue. Consumers are idempotent (IntegrationEventHandlerBase),
                 // so redelivery is safe.
                 cfg.UseMessageRetry(r => r.Exponential(
-                    retryLimit: 5,
-                    minInterval: TimeSpan.FromSeconds(1),
-                    maxInterval: TimeSpan.FromMinutes(2),
-                    intervalDelta: TimeSpan.FromSeconds(5)));
+                    retryLimit: opts.RetryLimit,
+                    minInterval: TimeSpan.FromMilliseconds(opts.RetryMinIntervalMs),
+                    maxInterval: TimeSpan.FromMilliseconds(opts.RetryMaxIntervalMs),
+                    intervalDelta: TimeSpan.FromMilliseconds(opts.RetryIntervalDeltaMs)));
 
                 cfg.ConfigureEndpoints(ctx);
             });

--- a/src/Host/Host/Infrastructure/Setup.MassTransit.cs
+++ b/src/Host/Host/Infrastructure/Setup.MassTransit.cs
@@ -52,6 +52,15 @@ internal static partial class Setup
                     h.PublisherConfirmation = true;
                 });
 
+                // Transient consumer failures (DB blips, pool timeouts) retry with backoff instead of
+                // faulting straight to the _error queue. Consumers are idempotent (IntegrationEventHandlerBase),
+                // so redelivery is safe.
+                cfg.UseMessageRetry(r => r.Exponential(
+                    retryLimit: 5,
+                    minInterval: TimeSpan.FromSeconds(1),
+                    maxInterval: TimeSpan.FromMinutes(2),
+                    intervalDelta: TimeSpan.FromSeconds(5)));
+
                 cfg.ConfigureEndpoints(ctx);
             });
         });

--- a/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/SelfRegister/Endpoint.cs
+++ b/src/Modules/IAM/IAM.Endpoints/Users/VersionNeutral/SelfRegister/Endpoint.cs
@@ -74,6 +74,13 @@ internal static class Endpoint
             new VerifyPhoneOtpRequest(request.PhoneNumber, request.Otp, OtpPurposes.Registration),
             cancellationToken);
 
+        // One transaction for the whole user + role + session sequence: userManager.CreateAsync
+        // and userManager.AddToRoleAsync each call SaveChanges internally, but both share this
+        // DbContext/connection, so they participate in the same ambient transaction as the final
+        // db.SaveChangesAsync below. A failure anywhere in the chain rolls back everything instead
+        // of leaving a half-registered user (no role/session) that a retry can't recover from.
+        await using var transaction = await db.Database.BeginTransactionAsync(cancellationToken);
+
         return await verifyOtpResponse
             .ToResult()
             .BindAsync(async () =>
@@ -117,6 +124,7 @@ internal static class Endpoint
                     RefreshTokenExpiresAt = refreshTokenExpiresAt
                 });
             })
+            .TapAsync(async _ => await transaction.CommitAsync(cancellationToken))
             .TapAsync(_ => IamTelemetry.UsersRegistered.Add(1))
             .TapAsync(_ => IamTelemetry.Logins.Add(1));
     }

--- a/src/Modules/IAM/IAM.Infrastructure/Captcha/Services/ReCaptchaService.cs
+++ b/src/Modules/IAM/IAM.Infrastructure/Captcha/Services/ReCaptchaService.cs
@@ -25,16 +25,15 @@ internal partial class ReCaptchaService(
 
     public async Task<Result> ValidateAsync(string captchaToken, CancellationToken cancellationToken)
     {
-        HttpResponseMessage httpResponseMessage;
-        using (var requestContent = GetRequestParameters(captchaToken, captchaOptionsProvider.Value.SecretKey))
-        {
-            // Use relative URI so the resilient HttpClient pipeline (retry, circuit breaker, timeout) is applied.
-            // BaseAddress is configured in the HttpClient registration (Captcha/Setup.cs).
-            httpResponseMessage = await httpClient.PostAsync(
-                new Uri(captchaOptionsProvider.Value.CaptchaEndpoint, UriKind.RelativeOrAbsolute),
-                requestContent,
-                cancellationToken);
-        }
+        using var requestContent = GetRequestParameters(captchaToken, captchaOptionsProvider.Value.SecretKey);
+
+        // A relative URI is used here so that the resilient HttpClient pipeline (retry, circuit
+        // breaker, timeout) still applies. The base address is configured where this HttpClient
+        // is registered, in the Captcha module setup.
+        using var httpResponseMessage = await httpClient.PostAsync(
+            new Uri(captchaOptionsProvider.Value.CaptchaEndpoint, UriKind.RelativeOrAbsolute),
+            requestContent,
+            cancellationToken);
 
         if (httpResponseMessage is not { IsSuccessStatusCode: true } succeededResult)
         {

--- a/src/Modules/IAM/IAM.Infrastructure/Captcha/Setup.cs
+++ b/src/Modules/IAM/IAM.Infrastructure/Captcha/Setup.cs
@@ -40,8 +40,9 @@ public static class Setup
             resilience =>
             {
                 // reCAPTCHA is a fast API — tighten timeouts.
-                resilience.AttemptTimeout.Timeout = TimeSpan.FromSeconds(5);
-                resilience.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(15);
+                resilience.AttemptTimeout.Timeout = TimeSpan.FromSeconds(captchaOptions.AttemptTimeoutSeconds);
+                resilience.TotalRequestTimeout.Timeout =
+                    TimeSpan.FromSeconds(captchaOptions.TotalRequestTimeoutSeconds);
             });
 
         return services;

--- a/src/Modules/IAM/IAM.Infrastructure/Captcha/Setup.cs
+++ b/src/Modules/IAM/IAM.Infrastructure/Captcha/Setup.cs
@@ -1,3 +1,4 @@
+using Common.Application.Extensions;
 using Common.Application.Options;
 using Common.Infrastructure.Resiliency;
 using IAM.Application.Captcha.Services;
@@ -17,8 +18,7 @@ public static class Setup
 
         if (string.Equals(captchaOptions.Provider, "Dummy", StringComparison.OrdinalIgnoreCase))
         {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            if (string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase))
+            if (services.IsProductionEnvironment())
             {
                 throw new InvalidOperationException(
                     "CaptchaOptions.Provider is 'Dummy' in Production. Dummy captcha always passes; " +

--- a/src/Modules/IAM/IAM.Infrastructure/Captcha/Setup.cs
+++ b/src/Modules/IAM/IAM.Infrastructure/Captcha/Setup.cs
@@ -1,3 +1,5 @@
+using Common.Application.Options;
+using Common.Infrastructure.Resiliency;
 using IAM.Application.Captcha.Services;
 using IAM.Infrastructure.Captcha.Services;
 using Microsoft.Extensions.Configuration;
@@ -10,25 +12,38 @@ public static class Setup
     public static IServiceCollection AddCaptchaInfrastructure(this IServiceCollection services,
         IConfiguration configuration)
     {
-        return services.AddSingleton<ICaptchaService, DummyCaptchaService>();
+        var captchaOptions = configuration.GetSection(nameof(CaptchaOptions)).Get<CaptchaOptions>()
+            ?? throw new InvalidOperationException($"Configuration for {nameof(CaptchaOptions)} is null.");
 
-        // services.AddResilientHttpClient<ICaptchaService, ReCaptchaService>(
-        //     httpClient =>
-#pragma warning disable S125
-        //     {
-#pragma warning restore S125
-        //         httpClient.BaseAddress = new Uri(captchaOptions.BaseUrl);
-        //     },
-        //     resilience =>
-        //     {
-        //         // reCAPTCHA is a fast API — tighten per-attempt timeout
-        //         resilience.AttemptTimeout.Timeout = TimeSpan.FromSeconds(5);
-        //         resilience.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(15);
-        //     })
-        //     .Services
-        //     .Decorate<ICaptchaService>((decoree, sp) => new CachedCaptchaService(
-        //         decoree,
-        //         sp.GetRequiredService<IFusionCache>(),
-        //         sp.GetRequiredService<IOptions<OtpOptions>>()));
+        if (string.Equals(captchaOptions.Provider, "Dummy", StringComparison.OrdinalIgnoreCase))
+        {
+            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            if (string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "CaptchaOptions.Provider is 'Dummy' in Production. Dummy captcha always passes; " +
+                    "set Provider to 'ReCaptcha' (with real keys) before deploying.");
+            }
+
+            return services.AddSingleton<ICaptchaService, DummyCaptchaService>();
+        }
+
+        services.AddResilientHttpClient<ICaptchaService, ReCaptchaService>(
+            httpClient =>
+            {
+                // Trailing slash is REQUIRED: HttpClient drops the last BaseAddress segment
+                // when combining with a relative URI otherwise.
+#pragma warning disable S1075
+                httpClient.BaseAddress = new Uri(captchaOptions.BaseUrl.TrimEnd('/') + '/');
+#pragma warning restore S1075
+            },
+            resilience =>
+            {
+                // reCAPTCHA is a fast API — tighten timeouts.
+                resilience.AttemptTimeout.Timeout = TimeSpan.FromSeconds(5);
+                resilience.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(15);
+            });
+
+        return services;
     }
 }

--- a/src/Modules/IAM/IAM.Infrastructure/Persistence/Migrations/20260719143858_AuditLogCreatedOnIndex.Designer.cs
+++ b/src/Modules/IAM/IAM.Infrastructure/Persistence/Migrations/20260719143858_AuditLogCreatedOnIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace IAM.Infrastructure.Migrations
 {
     [DbContext(typeof(IAMDbContext))]
-    partial class IAMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719143858_AuditLogCreatedOnIndex")]
+    partial class AuditLogCreatedOnIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/IAM/IAM.Infrastructure/Persistence/Migrations/20260719143858_AuditLogCreatedOnIndex.cs
+++ b/src/Modules/IAM/IAM.Infrastructure/Persistence/Migrations/20260719143858_AuditLogCreatedOnIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IAM.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AuditLogCreatedOnIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLog_CreatedOn",
+                schema: "IAM",
+                table: "AuditLog",
+                column: "CreatedOn");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLog_CreatedOn",
+                schema: "IAM",
+                table: "AuditLog");
+        }
+    }
+}

--- a/src/Modules/IAM/IAM.Tests/Captcha/CaptchaSetupTests.cs
+++ b/src/Modules/IAM/IAM.Tests/Captcha/CaptchaSetupTests.cs
@@ -19,7 +19,9 @@ public class CaptchaSetupTests
                 { $"{nameof(CaptchaOptions)}:BaseUrl", "https://www.google.com/recaptcha/api" },
                 { $"{nameof(CaptchaOptions)}:CaptchaEndpoint", "siteverify" },
                 { $"{nameof(CaptchaOptions)}:ClientKey", "clientKey" },
-                { $"{nameof(CaptchaOptions)}:SecretKey", "secretKey" }
+                { $"{nameof(CaptchaOptions)}:SecretKey", "secretKey" },
+                { $"{nameof(CaptchaOptions)}:AttemptTimeoutSeconds", "5" },
+                { $"{nameof(CaptchaOptions)}:TotalRequestTimeoutSeconds", "15" }
             })
             .Build();
     }

--- a/src/Modules/IAM/IAM.Tests/Captcha/CaptchaSetupTests.cs
+++ b/src/Modules/IAM/IAM.Tests/Captcha/CaptchaSetupTests.cs
@@ -1,9 +1,11 @@
 using Common.Application.Options;
+using Common.Tests;
 using IAM.Application.Captcha.Services;
 using IAM.Infrastructure.Captcha;
 using IAM.Infrastructure.Captcha.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace IAM.Tests.Captcha;
@@ -26,50 +28,39 @@ public class CaptchaSetupTests
             .Build();
     }
 
+    private static ServiceCollection BuildServices(string environmentName)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment(environmentName));
+        return services;
+    }
+
     [Fact]
     public void AddCaptchaInfrastructure_DummyProviderInProduction_Throws()
     {
-        var previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
-        try
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration("Dummy");
+        var services = BuildServices(Environments.Production);
+        var configuration = BuildConfiguration("Dummy");
 
-            Assert.Throws<InvalidOperationException>(() => services.AddCaptchaInfrastructure(configuration));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousEnvironment);
-        }
+        Assert.Throws<InvalidOperationException>(() => services.AddCaptchaInfrastructure(configuration));
     }
 
     [Fact]
     public void AddCaptchaInfrastructure_DummyProviderInDevelopment_RegistersDummy()
     {
-        var previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
-        try
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration("Dummy");
+        var services = BuildServices(Environments.Development);
+        var configuration = BuildConfiguration("Dummy");
 
-            services.AddCaptchaInfrastructure(configuration);
+        services.AddCaptchaInfrastructure(configuration);
 
-            Assert.Contains(services, descriptor =>
-                descriptor.ServiceType == typeof(ICaptchaService) &&
-                descriptor.ImplementationType == typeof(DummyCaptchaService));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousEnvironment);
-        }
+        Assert.Contains(services, descriptor =>
+            descriptor.ServiceType == typeof(ICaptchaService) &&
+            descriptor.ImplementationType == typeof(DummyCaptchaService));
     }
 
     [Fact]
     public void AddCaptchaInfrastructure_ReCaptchaProvider_RegistersTypedHttpClient()
     {
-        var services = new ServiceCollection();
+        var services = BuildServices(Environments.Development);
         var configuration = BuildConfiguration("ReCaptcha");
 
         services.AddCaptchaInfrastructure(configuration);

--- a/src/Modules/IAM/IAM.Tests/Captcha/CaptchaSetupTests.cs
+++ b/src/Modules/IAM/IAM.Tests/Captcha/CaptchaSetupTests.cs
@@ -1,0 +1,78 @@
+using Common.Application.Options;
+using IAM.Application.Captcha.Services;
+using IAM.Infrastructure.Captcha;
+using IAM.Infrastructure.Captcha.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace IAM.Tests.Captcha;
+
+public class CaptchaSetupTests
+{
+    private static IConfiguration BuildConfiguration(string provider)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { $"{nameof(CaptchaOptions)}:Provider", provider },
+                { $"{nameof(CaptchaOptions)}:BaseUrl", "https://www.google.com/recaptcha/api" },
+                { $"{nameof(CaptchaOptions)}:CaptchaEndpoint", "siteverify" },
+                { $"{nameof(CaptchaOptions)}:ClientKey", "clientKey" },
+                { $"{nameof(CaptchaOptions)}:SecretKey", "secretKey" }
+            })
+            .Build();
+    }
+
+    [Fact]
+    public void AddCaptchaInfrastructure_DummyProviderInProduction_Throws()
+    {
+        var previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+        try
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration("Dummy");
+
+            Assert.Throws<InvalidOperationException>(() => services.AddCaptchaInfrastructure(configuration));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousEnvironment);
+        }
+    }
+
+    [Fact]
+    public void AddCaptchaInfrastructure_DummyProviderInDevelopment_RegistersDummy()
+    {
+        var previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+        try
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration("Dummy");
+
+            services.AddCaptchaInfrastructure(configuration);
+
+            Assert.Contains(services, descriptor =>
+                descriptor.ServiceType == typeof(ICaptchaService) &&
+                descriptor.ImplementationType == typeof(DummyCaptchaService));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousEnvironment);
+        }
+    }
+
+    [Fact]
+    public void AddCaptchaInfrastructure_ReCaptchaProvider_RegistersTypedHttpClient()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration("ReCaptcha");
+
+        services.AddCaptchaInfrastructure(configuration);
+
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(ICaptchaService));
+        Assert.DoesNotContain(services, descriptor => descriptor.ImplementationType == typeof(DummyCaptchaService));
+    }
+}

--- a/src/Modules/IAM/IAM.Tests/Endpoints/Users/SelfRegisterTests.cs
+++ b/src/Modules/IAM/IAM.Tests/Endpoints/Users/SelfRegisterTests.cs
@@ -216,6 +216,68 @@ public class SelfRegisterTests : BaseIntegrationTest
     }
 
     [Fact]
+    public async Task SelfRegister_RoleAssignmentFails_NothingPersisted()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var cache = scope.ServiceProvider.GetRequiredService<IFusionCache>();
+        var db = scope.ServiceProvider.GetRequiredService<IIAMDbContext>();
+        var outboxDb = scope.ServiceProvider.GetRequiredService<IOutboxDbContext>();
+        await EnsureBasicRoleExistsAsync(scope);
+
+        // Delete the Basic role so AddToRoleAsync fails mid-sequence — CreateAsync has
+        // already run (and, pre-fix, already committed) by the time this failure occurs.
+        var basicRole = await db.Roles.SingleAsync(r => r.Name == CustomRoles.Basic);
+        db.Roles.Remove(basicRole);
+        await db.SaveChangesAsync();
+
+        var phoneNumber = "905" + _faker.Random.Number(100000000, 999999999).ToString(CultureInfo.InvariantCulture);
+        var otp = "123456";
+
+        var cacheKey = CacheKeys.For.Otp(phoneNumber, "registration");
+        await cache.SetAsync(cacheKey, new OtpCacheEntry(otp, 0, DateTimeOffset.UtcNow.AddMinutes(5)),
+            new FusionCacheEntryOptions { Duration = TimeSpan.FromMinutes(5) });
+
+        var sessionCountBefore = await db.Sessions.AsNoTracking().CountAsync();
+        var auditCountBefore = await db.AuditLog.AsNoTracking().CountAsync();
+        var outboxCountBefore = await outboxDb.OutboxMessages.AsNoTracking().CountAsync();
+
+        var client = Factory.CreateClient();
+        var request = new Request
+        {
+            PhoneNumber = phoneNumber,
+            Otp = otp,
+            FullName = _faker.Name.FullName() + " Yılmaz",
+            BirthDate = _faker.Date.Past(30).ToString(Constants.TurkishDateFormat, CultureInfo.InvariantCulture),
+            CaptchaToken = "dummyToken",
+            DeviceId = Guid.NewGuid(),
+            ClientId = "mobile-app-1"
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync(new Uri("/users/register/self", UriKind.Relative), request);
+
+        // Assert — non-success response
+        Assert.False(response.IsSuccessStatusCode);
+
+        // Assert — nothing persisted: the whole user+role+session sequence rolled back atomically
+        var createdUser = await db.Users.AsNoTracking().SingleOrDefaultAsync(u => u.PhoneNumber == phoneNumber);
+        Assert.Null(createdUser);
+
+        var sessionCountAfter = await db.Sessions.AsNoTracking().CountAsync();
+        Assert.Equal(sessionCountBefore, sessionCountAfter);
+
+        var auditCountAfter = await db.AuditLog.AsNoTracking().CountAsync();
+        Assert.Equal(auditCountBefore, auditCountAfter);
+
+        var outboxCountAfter = await outboxDb.OutboxMessages.AsNoTracking().CountAsync();
+        Assert.Equal(outboxCountBefore, outboxCountAfter);
+
+        // No manual restore of the Basic role — Respawn resets DB state (including seed data
+        // each test re-creates via EnsureBasicRoleExistsAsync) between tests in this collection.
+    }
+
+    [Fact]
     public async Task SelfRegister_WithInvalidCaptcha_ReturnsBadRequest()
     {
         // Arrange

--- a/src/Modules/Notifications/Notifications.Infrastructure/Hubs/Setup.SignalR.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Hubs/Setup.SignalR.cs
@@ -11,6 +11,16 @@ internal static class Setup
     {
         var options = configuration.GetSection(nameof(SignalROptions)).Get<SignalROptions>();
 
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var isProduction = string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase);
+
+        if (isProduction && options?.UseRedisBackplane != true)
+        {
+            throw new InvalidOperationException(
+                "SignalROptions.UseRedisBackplane is false in Production. " +
+                "Multi-instance deployments require the Redis backplane for SignalR fan-out.");
+        }
+
         var builder = services.AddSignalR();
 
         if (options?.UseRedisBackplane == true)

--- a/src/Modules/Notifications/Notifications.Infrastructure/Hubs/Setup.SignalR.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Hubs/Setup.SignalR.cs
@@ -1,7 +1,9 @@
 using Common.Application.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Notifications.Application.Hubs;
+using StackExchange.Redis;
 
 namespace Notifications.Infrastructure.Hubs;
 
@@ -15,7 +17,19 @@ internal static class Setup
 
         if (options?.UseRedisBackplane == true)
         {
-            builder.AddStackExchangeRedis(options.RedisConnectionString);
+            builder.AddStackExchangeRedis(_ => { }); // options configured below with DI access
+
+            services.AddSingleton<IConfigureOptions<Microsoft.AspNetCore.SignalR.StackExchangeRedis.RedisOptions>>(sp =>
+                new ConfigureOptions<Microsoft.AspNetCore.SignalR.StackExchangeRedis.RedisOptions>(redisOptions =>
+                {
+                    // Reuse the app-wide multiplexer registered by AddCommonCaching when Redis caching
+                    // is on; otherwise dial the backplane's own connection string.
+                    var shared = sp.GetService<IConnectionMultiplexer>();
+                    redisOptions.ConnectionFactory = shared is not null
+                        ? _ => Task.FromResult<IConnectionMultiplexer>(shared)
+                        : async writer => await ConnectionMultiplexer.ConnectAsync(
+                            options.RedisConnectionString, writer);
+                }));
         }
 
         services.AddSingleton<INotificationDispatcher, SignalRNotificationDispatcher>();

--- a/src/Modules/Notifications/Notifications.Infrastructure/Hubs/Setup.SignalR.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Hubs/Setup.SignalR.cs
@@ -1,3 +1,4 @@
+using Common.Application.Extensions;
 using Common.Application.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,10 +14,7 @@ internal static class Setup
     {
         var options = configuration.GetSection(nameof(SignalROptions)).Get<SignalROptions>();
 
-        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        var isProduction = string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase);
-
-        if (isProduction && options?.UseRedisBackplane != true)
+        if (services.IsProductionEnvironment() && options?.UseRedisBackplane != true)
         {
             throw new InvalidOperationException(
                 "SignalROptions.UseRedisBackplane is false in Production. " +

--- a/src/Modules/Notifications/Notifications.Infrastructure/NotificationsModule.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/NotificationsModule.cs
@@ -21,7 +21,7 @@ public sealed class NotificationsModule : IModule
     {
         services.AddNotificationServices();
         services.AddNotificationsSignalR(configuration);
-        services.AddOtpServices();
+        services.AddOtpServices(configuration);
     }
 
     public void UseModule(IApplicationBuilder app)

--- a/src/Modules/Notifications/Notifications.Infrastructure/Otp/OtpServiceBase.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Otp/OtpServiceBase.cs
@@ -8,6 +8,10 @@ internal abstract class OtpServiceBase(IFusionCache cache) : IOtpService
 {
     private const int MaxFailedAttempts = 3;
 
+    // Only registered when CachingOptions.UseRedis = false, i.e. single-instance dev/test — a global lock
+    // is correct there. Multi-instance atomicity in production is provided by RedisOtpService's Lua script.
+    private static readonly SemaphoreSlim VerifyLock = new(1, 1);
+
     public async Task StoreAsync(string phoneNumber, string otp, string purpose, TimeSpan duration, string? contextId,
         CancellationToken cancellationToken)
     {
@@ -24,43 +28,51 @@ internal abstract class OtpServiceBase(IFusionCache cache) : IOtpService
         string? contextId,
         CancellationToken cancellationToken)
     {
-        var cacheKey = CacheKeys.For.Otp(phoneNumber, purpose, contextId);
-
-        var entry = await cache.GetOrDefaultAsync<OtpCacheEntry>(cacheKey, token: cancellationToken);
-
-        if (entry is null)
+        await VerifyLock.WaitAsync(cancellationToken);
+        try
         {
-            return OtpVerificationOutcome.InvalidOtp;
-        }
+            var cacheKey = CacheKeys.For.Otp(phoneNumber, purpose, contextId);
 
-        if (!string.Equals(entry.Otp, otp, StringComparison.Ordinal))
-        {
-            var updatedFailedAttempts = entry.FailedAttempts + 1;
+            var entry = await cache.GetOrDefaultAsync<OtpCacheEntry>(cacheKey, token: cancellationToken);
 
-            if (updatedFailedAttempts >= MaxFailedAttempts)
-            {
-                await cache.RemoveAsync(cacheKey, token: cancellationToken);
-                return OtpVerificationOutcome.TooManyAttempts;
-            }
-
-            var remaining = entry.ExpiresAt - DateTimeOffset.UtcNow;
-            if (remaining <= TimeSpan.Zero)
+            if (entry is null)
             {
                 return OtpVerificationOutcome.InvalidOtp;
             }
 
-            await cache.SetAsync(
-                cacheKey,
-                entry with { FailedAttempts = updatedFailedAttempts },
-                new FusionCacheEntryOptions { Duration = remaining },
-                token: cancellationToken);
+            if (!string.Equals(entry.Otp, otp, StringComparison.Ordinal))
+            {
+                var updatedFailedAttempts = entry.FailedAttempts + 1;
 
-            return OtpVerificationOutcome.InvalidOtp;
+                if (updatedFailedAttempts >= MaxFailedAttempts)
+                {
+                    await cache.RemoveAsync(cacheKey, token: cancellationToken);
+                    return OtpVerificationOutcome.TooManyAttempts;
+                }
+
+                var remaining = entry.ExpiresAt - DateTimeOffset.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    return OtpVerificationOutcome.InvalidOtp;
+                }
+
+                await cache.SetAsync(
+                    cacheKey,
+                    entry with { FailedAttempts = updatedFailedAttempts },
+                    new FusionCacheEntryOptions { Duration = remaining },
+                    token: cancellationToken);
+
+                return OtpVerificationOutcome.InvalidOtp;
+            }
+
+            await cache.RemoveAsync(cacheKey, token: cancellationToken);
+
+            return OtpVerificationOutcome.Success;
         }
-
-        await cache.RemoveAsync(cacheKey, token: cancellationToken);
-
-        return OtpVerificationOutcome.Success;
+        finally
+        {
+            VerifyLock.Release();
+        }
     }
 
     public abstract string Generate();

--- a/src/Modules/Notifications/Notifications.Infrastructure/Otp/RedisOtpService.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Otp/RedisOtpService.cs
@@ -10,8 +10,8 @@ namespace Notifications.Infrastructure.Otp;
 /// <summary>
 ///     Redis-backed OTP store. Verification is a single atomic Lua script so concurrent attempts
 ///     cannot bypass the failed-attempt cap or consume the same OTP twice — across all instances.
-///     No automated test covers this class (no Redis container in CI); the script was verified manually
-///     against a local Redis instance. Do not "optimize" the script — keep it exactly as written.
+///     No automated test covers this class (no Redis container in CI); the scripts were verified manually
+///     against a local Redis instance. Do not "optimize" the scripts — keep them exactly as written.
 /// </summary>
 internal sealed class RedisOtpService(
     IConnectionMultiplexer redis,
@@ -37,13 +37,22 @@ internal sealed class RedisOtpService(
         return 0
         """;
 
+    // KEYS[1] = otp key, ARGV[1] = otp, ARGV[2] = ttl in milliseconds
+    // Single atomic EVAL: HSET and PEXPIRE must not be separate round trips — a disconnect between
+    // them would leave an OTP key with no TTL (a never-expiring OTP).
+    private const string StoreScript =
+        """
+        redis.call('HSET', KEYS[1], 'otp', ARGV[1], 'failed', 0)
+        redis.call('PEXPIRE', KEYS[1], ARGV[2])
+        return 1
+        """;
+
     public async Task StoreAsync(string phoneNumber, string otp, string purpose, TimeSpan duration,
         string? contextId, CancellationToken cancellationToken)
     {
         var key = CacheKeys.For.Otp(phoneNumber, purpose, contextId);
         var db = redis.GetDatabase();
-        await db.HashSetAsync(key, [new HashEntry("otp", otp), new HashEntry("failed", 0)]);
-        await db.KeyExpireAsync(key, duration);
+        await db.ScriptEvaluateAsync(StoreScript, [(RedisKey)key], [otp, (long)duration.TotalMilliseconds]);
     }
 
     public async Task<OtpVerificationOutcome> VerifyThenRemoveAsync(string phoneNumber, string otp,

--- a/src/Modules/Notifications/Notifications.Infrastructure/Otp/RedisOtpService.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Otp/RedisOtpService.cs
@@ -1,0 +1,81 @@
+using System.Security.Cryptography;
+using Common.Application.Caching;
+using Common.Application.Options;
+using Microsoft.Extensions.Options;
+using Notifications.Application.Otp;
+using StackExchange.Redis;
+
+namespace Notifications.Infrastructure.Otp;
+
+/// <summary>
+///     Redis-backed OTP store. Verification is a single atomic Lua script so concurrent attempts
+///     cannot bypass the failed-attempt cap or consume the same OTP twice — across all instances.
+///     No automated test covers this class (no Redis container in CI); the script was verified manually
+///     against a local Redis instance. Do not "optimize" the script — keep it exactly as written.
+/// </summary>
+internal sealed class RedisOtpService(
+    IConnectionMultiplexer redis,
+    IOptions<OtpOptions> otpOptionsProvider) : IOtpService
+{
+    private const int MaxFailedAttempts = 3;
+
+    // KEYS[1] = otp key, ARGV[1] = provided otp, ARGV[2] = max failed attempts
+    // Returns: 1 = success, 0 = invalid, 2 = too many attempts
+    private const string VerifyScript =
+        """
+        local otp = redis.call('HGET', KEYS[1], 'otp')
+        if not otp then return 0 end
+        if otp == ARGV[1] then
+            redis.call('DEL', KEYS[1])
+            return 1
+        end
+        local failed = redis.call('HINCRBY', KEYS[1], 'failed', 1)
+        if failed >= tonumber(ARGV[2]) then
+            redis.call('DEL', KEYS[1])
+            return 2
+        end
+        return 0
+        """;
+
+    public async Task StoreAsync(string phoneNumber, string otp, string purpose, TimeSpan duration,
+        string? contextId, CancellationToken cancellationToken)
+    {
+        var key = CacheKeys.For.Otp(phoneNumber, purpose, contextId);
+        var db = redis.GetDatabase();
+        await db.HashSetAsync(key, [new HashEntry("otp", otp), new HashEntry("failed", 0)]);
+        await db.KeyExpireAsync(key, duration);
+    }
+
+    public async Task<OtpVerificationOutcome> VerifyThenRemoveAsync(string phoneNumber, string otp,
+        string purpose, string? contextId, CancellationToken cancellationToken)
+    {
+        var key = CacheKeys.For.Otp(phoneNumber, purpose, contextId);
+        var db = redis.GetDatabase();
+        var result = (long)await db.ScriptEvaluateAsync(VerifyScript, [(RedisKey)key], [otp, MaxFailedAttempts]);
+
+        return result switch
+        {
+            1 => OtpVerificationOutcome.Success,
+            2 => OtpVerificationOutcome.TooManyAttempts,
+            _ => OtpVerificationOutcome.InvalidOtp,
+        };
+    }
+
+    public string Generate()
+    {
+        var length = otpOptionsProvider.Value.Length;
+
+        if (length <= 0)
+        {
+            throw new ArgumentException("Length must be greater than zero.");
+        }
+
+        var otp = new char[length];
+        for (var i = 0; i < length; i++)
+        {
+            otp[i] = (char)('0' + RandomNumberGenerator.GetInt32(0, 10));
+        }
+
+        return new string(otp);
+    }
+}

--- a/src/Modules/Notifications/Notifications.Infrastructure/Otp/Setup.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Otp/Setup.cs
@@ -1,3 +1,5 @@
+using Common.Application.Options;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Notifications.Application.Otp;
 using Notifications.Application.Sms;
@@ -7,9 +9,21 @@ namespace Notifications.Infrastructure.Otp;
 
 internal static class Setup
 {
-    public static IServiceCollection AddOtpServices(this IServiceCollection services)
-        => services
-            //.AddSingleton<IOtpService, OtpService>()
-            .AddSingleton<IOtpService, DummyOtpService>()
-            .AddSingleton<ISmsGateway, DummySmsGateway>();
+    public static IServiceCollection AddOtpServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        var useRedis = configuration.GetSection(nameof(CachingOptions)).GetValue<bool>(nameof(CachingOptions.UseRedis));
+
+        if (useRedis)
+        {
+            services.AddSingleton<IOtpService, RedisOtpService>();
+        }
+        else
+        {
+            services
+                //.AddSingleton<IOtpService, OtpService>()
+                .AddSingleton<IOtpService, DummyOtpService>();
+        }
+
+        return services.AddSingleton<ISmsGateway, DummySmsGateway>();
+    }
 }

--- a/src/Modules/Notifications/Notifications.Infrastructure/Otp/Setup.cs
+++ b/src/Modules/Notifications/Notifications.Infrastructure/Otp/Setup.cs
@@ -1,3 +1,4 @@
+using Common.Application.Extensions;
 using Common.Application.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,6 +12,16 @@ internal static class Setup
 {
     public static IServiceCollection AddOtpServices(this IServiceCollection services, IConfiguration configuration)
     {
+        // DummySmsGateway is a no-op: OTPs are generated and stored but never reach the user.
+        // In Production that silently bricks every OTP flow (registration included), so fail fast
+        // until a real ISmsGateway implementation exists and is registered here.
+        if (services.IsProductionEnvironment())
+        {
+            throw new InvalidOperationException(
+                $"{nameof(ISmsGateway)} is {nameof(DummySmsGateway)} (no-op) — OTPs would never reach users in Production. " +
+                "Implement and register a real SMS gateway before deploying the Notifications module.");
+        }
+
         var useRedis = configuration.GetSection(nameof(CachingOptions)).GetValue<bool>(nameof(CachingOptions.UseRedis));
 
         if (useRedis)

--- a/src/Modules/Notifications/Notifications.Tests/Hubs/SignalRSetupTests.cs
+++ b/src/Modules/Notifications/Notifications.Tests/Hubs/SignalRSetupTests.cs
@@ -1,5 +1,7 @@
+using Common.Tests;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Notifications.Infrastructure.Hubs;
 using Xunit;
 
@@ -16,56 +18,40 @@ public sealed class SignalRSetupTests
             })
             .Build();
 
-    private static void WithEnvironment(string? environment, Action action)
+    private static ServiceCollection BuildServices(string environmentName)
     {
-        var original = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        try
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
-            action();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", original);
-        }
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment(environmentName));
+        return services;
     }
 
     [Fact]
     public void AddNotificationsSignalR_ProductionWithoutRedisBackplane_Throws()
     {
-        WithEnvironment("Production", () =>
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration(useRedisBackplane: false);
+        var services = BuildServices(Environments.Production);
+        var configuration = BuildConfiguration(useRedisBackplane: false);
 
-            var exception = Assert.Throws<InvalidOperationException>(
-                () => services.AddNotificationsSignalR(configuration));
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddNotificationsSignalR(configuration));
 
-            Assert.Contains("UseRedisBackplane", exception.Message, StringComparison.Ordinal);
-        });
+        Assert.Contains("UseRedisBackplane", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void AddNotificationsSignalR_ProductionWithRedisBackplane_DoesNotThrow()
     {
-        WithEnvironment("Production", () =>
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration(useRedisBackplane: true);
+        var services = BuildServices(Environments.Production);
+        var configuration = BuildConfiguration(useRedisBackplane: true);
 
-            services.AddNotificationsSignalR(configuration);
-        });
+        services.AddNotificationsSignalR(configuration);
     }
 
     [Fact]
     public void AddNotificationsSignalR_DevelopmentWithoutRedisBackplane_DoesNotThrow()
     {
-        WithEnvironment("Development", () =>
-        {
-            var services = new ServiceCollection();
-            var configuration = BuildConfiguration(useRedisBackplane: false);
+        var services = BuildServices(Environments.Development);
+        var configuration = BuildConfiguration(useRedisBackplane: false);
 
-            services.AddNotificationsSignalR(configuration);
-        });
+        services.AddNotificationsSignalR(configuration);
     }
 }

--- a/src/Modules/Notifications/Notifications.Tests/Hubs/SignalRSetupTests.cs
+++ b/src/Modules/Notifications/Notifications.Tests/Hubs/SignalRSetupTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Notifications.Infrastructure.Hubs;
+using Xunit;
+
+namespace Notifications.Tests.Hubs;
+
+public sealed class SignalRSetupTests
+{
+    private static IConfiguration BuildConfiguration(bool useRedisBackplane) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SignalROptions:UseRedisBackplane"] = useRedisBackplane.ToString(),
+                ["SignalROptions:RedisConnectionString"] = useRedisBackplane ? "localhost:6379" : "",
+            })
+            .Build();
+
+    private static void WithEnvironment(string? environment, Action action)
+    {
+        var original = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        try
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
+            action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", original);
+        }
+    }
+
+    [Fact]
+    public void AddNotificationsSignalR_ProductionWithoutRedisBackplane_Throws()
+    {
+        WithEnvironment("Production", () =>
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration(useRedisBackplane: false);
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => services.AddNotificationsSignalR(configuration));
+
+            Assert.Contains("UseRedisBackplane", exception.Message, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void AddNotificationsSignalR_ProductionWithRedisBackplane_DoesNotThrow()
+    {
+        WithEnvironment("Production", () =>
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration(useRedisBackplane: true);
+
+            services.AddNotificationsSignalR(configuration);
+        });
+    }
+
+    [Fact]
+    public void AddNotificationsSignalR_DevelopmentWithoutRedisBackplane_DoesNotThrow()
+    {
+        WithEnvironment("Development", () =>
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration(useRedisBackplane: false);
+
+            services.AddNotificationsSignalR(configuration);
+        });
+    }
+}

--- a/src/Modules/Notifications/Notifications.Tests/IntegrationEventHandlers/UserRegisteredSignalRHandlerTests.cs
+++ b/src/Modules/Notifications/Notifications.Tests/IntegrationEventHandlers/UserRegisteredSignalRHandlerTests.cs
@@ -34,6 +34,7 @@ public sealed class UserRegisteredSignalRHandlerTests : IDisposable
                 FactoryHardTimeout = TimeSpan.FromMilliseconds(1500),
             },
             IdempotencyKeyDuration = TimeSpan.FromDays(1),
+            IdempotencyL1Duration = TimeSpan.FromHours(1),
         });
         _handler = new UserRegisteredSignalRHandler(logger, _cache, cachingOptions, _dispatcher);
     }

--- a/src/Modules/Notifications/Notifications.Tests/IntegrationEventHandlers/UserRegisteredSmsHandlerTests.cs
+++ b/src/Modules/Notifications/Notifications.Tests/IntegrationEventHandlers/UserRegisteredSmsHandlerTests.cs
@@ -34,6 +34,7 @@ public sealed class UserRegisteredSmsHandlerTests : IDisposable
                 FactoryHardTimeout = TimeSpan.FromMilliseconds(1500),
             },
             IdempotencyKeyDuration = TimeSpan.FromDays(1),
+            IdempotencyL1Duration = TimeSpan.FromHours(1),
         });
         _handler = new UserRegisteredSmsHandler(logger, _cache, cachingOptions, _smsService);
     }

--- a/src/Modules/Notifications/Notifications.Tests/Otp/OtpServiceTests.cs
+++ b/src/Modules/Notifications/Notifications.Tests/Otp/OtpServiceTests.cs
@@ -1,0 +1,98 @@
+using Common.Application.Options;
+using Microsoft.Extensions.Options;
+using Notifications.Application.Otp;
+using Notifications.Infrastructure.Otp;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Notifications.Tests.Otp;
+
+public sealed class OtpServiceTests : IDisposable
+{
+    private const string PhoneNumber = "1234567890";
+    private const string Purpose = "login";
+    private const string Otp = "654321";
+
+    private readonly FusionCache _cache;
+    private readonly OtpService _sut;
+
+    public OtpServiceTests()
+    {
+        _cache = new FusionCache(new FusionCacheOptions());
+        var otpOptions = Options.Create(new OtpOptions { Length = 6, ExpirationInMinutes = 5 });
+        _sut = new OtpService(otpOptions, _cache);
+    }
+
+    public void Dispose()
+    {
+        _cache.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task VerifyThenRemove_ParallelWrongAttempts_CapNotBypassed()
+    {
+        await _sut.StoreAsync(PhoneNumber, Otp, Purpose, TimeSpan.FromMinutes(5), null, CancellationToken.None);
+
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => _sut.VerifyThenRemoveAsync(PhoneNumber, "000000", Purpose, null, CancellationToken.None));
+        var results = await Task.WhenAll(tasks);
+
+        Assert.True(results.Count(r => r == OtpVerificationOutcome.TooManyAttempts) <= 1);
+
+        var finalOutcome = await _sut.VerifyThenRemoveAsync(PhoneNumber, Otp, Purpose, null, CancellationToken.None);
+        Assert.Equal(OtpVerificationOutcome.InvalidOtp, finalOutcome);
+    }
+
+    [Fact]
+    public async Task VerifyThenRemove_ParallelCorrectAttempts_OnlyOneSucceeds()
+    {
+        await _sut.StoreAsync(PhoneNumber, Otp, Purpose, TimeSpan.FromMinutes(5), null, CancellationToken.None);
+
+        var tasks = Enumerable.Range(0, 2)
+            .Select(_ => _sut.VerifyThenRemoveAsync(PhoneNumber, Otp, Purpose, null, CancellationToken.None));
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, results.Count(r => r == OtpVerificationOutcome.Success));
+        Assert.Equal(1, results.Count(r => r == OtpVerificationOutcome.InvalidOtp));
+    }
+
+    [Fact]
+    public async Task VerifyThenRemove_SequentialWrongAttempts_ThirdReturnsTooManyAttempts()
+    {
+        await _sut.StoreAsync(PhoneNumber, Otp, Purpose, TimeSpan.FromMinutes(5), null, CancellationToken.None);
+
+        var first = await _sut.VerifyThenRemoveAsync(PhoneNumber, "000000", Purpose, null, CancellationToken.None);
+        var second = await _sut.VerifyThenRemoveAsync(PhoneNumber, "000000", Purpose, null, CancellationToken.None);
+        var third = await _sut.VerifyThenRemoveAsync(PhoneNumber, "000000", Purpose, null, CancellationToken.None);
+        var fourth = await _sut.VerifyThenRemoveAsync(PhoneNumber, Otp, Purpose, null, CancellationToken.None);
+
+        Assert.Equal(OtpVerificationOutcome.InvalidOtp, first);
+        Assert.Equal(OtpVerificationOutcome.InvalidOtp, second);
+        Assert.Equal(OtpVerificationOutcome.TooManyAttempts, third);
+        Assert.Equal(OtpVerificationOutcome.InvalidOtp, fourth);
+    }
+
+    [Fact]
+    public async Task VerifyThenRemove_ExpiredOtp_ReturnsInvalidOtp()
+    {
+        await _sut.StoreAsync(PhoneNumber, Otp, Purpose, TimeSpan.FromMilliseconds(50), null, CancellationToken.None);
+        await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+        var outcome = await _sut.VerifyThenRemoveAsync(PhoneNumber, Otp, Purpose, null, CancellationToken.None);
+
+        Assert.Equal(OtpVerificationOutcome.InvalidOtp, outcome);
+    }
+
+    [Fact]
+    public async Task VerifyThenRemove_CorrectOtp_SecondUseFails()
+    {
+        await _sut.StoreAsync(PhoneNumber, Otp, Purpose, TimeSpan.FromMinutes(5), null, CancellationToken.None);
+
+        var first = await _sut.VerifyThenRemoveAsync(PhoneNumber, Otp, Purpose, null, CancellationToken.None);
+        var second = await _sut.VerifyThenRemoveAsync(PhoneNumber, Otp, Purpose, null, CancellationToken.None);
+
+        Assert.Equal(OtpVerificationOutcome.Success, first);
+        Assert.Equal(OtpVerificationOutcome.InvalidOtp, second);
+    }
+}

--- a/src/Modules/Notifications/Notifications.Tests/Otp/OtpSetupTests.cs
+++ b/src/Modules/Notifications/Notifications.Tests/Otp/OtpSetupTests.cs
@@ -1,0 +1,51 @@
+using Common.Tests;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Notifications.Application.Sms;
+using Notifications.Infrastructure.Otp;
+using Notifications.Infrastructure.Sms;
+using Xunit;
+
+namespace Notifications.Tests.Otp;
+
+public sealed class OtpSetupTests
+{
+    private static IConfiguration BuildConfiguration(bool useRedis) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CachingOptions:UseRedis"] = useRedis.ToString(),
+            })
+            .Build();
+
+    private static ServiceCollection BuildServices(string environmentName)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment(environmentName));
+        return services;
+    }
+
+    [Fact]
+    public void AddOtpServices_Production_ThrowsBecauseSmsGatewayIsDummy()
+    {
+        var services = BuildServices(Environments.Production);
+        var configuration = BuildConfiguration(useRedis: true);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddOtpServices(configuration));
+
+        Assert.Contains(nameof(DummySmsGateway), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddOtpServices_Development_DoesNotThrow()
+    {
+        var services = BuildServices(Environments.Development);
+        var configuration = BuildConfiguration(useRedis: false);
+
+        services.AddOtpServices(configuration);
+
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(ISmsGateway));
+    }
+}

--- a/src/Modules/Outbox/Outbox.Tests/AssemblyInfo.cs
+++ b/src/Modules/Outbox/Outbox.Tests/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+// Two WebApplicationFactory-based fixtures live in this assembly (OutboxTestWebAppFactory,
+// OutboxProcessorTestFactory) and they cannot share one factory: the backoff tests need the
+// OutboxProcessor poller running, the processor tests need it off so direct ProcessBatchAsync
+// calls don't race a background poller stealing claims. Parallel factory boots corrupt shared
+// global state (Serilog static logger, OTel ActivitySource) — see CLAUDE.md §8 — so run the
+// assembly sequentially instead.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/Modules/Outbox/Outbox.Tests/FakePublishEndpoint.cs
+++ b/src/Modules/Outbox/Outbox.Tests/FakePublishEndpoint.cs
@@ -1,0 +1,53 @@
+using MassTransit;
+
+namespace Outbox.Tests;
+
+// Test double for IPublishEndpoint. OutboxProcessor.ProcessBatchAsync only ever calls the
+// Publish(object, Type, CancellationToken) overload, so that's the only member with real behavior —
+// everything else on this (large) MassTransit interface is unused here and throws if ever hit.
+// Registered as a singleton in OutboxProcessorTestFactory, replacing the real bus, so tests can force
+// deterministic publish successes/failures without a RabbitMQ broker.
+internal sealed class FakePublishEndpoint : IPublishEndpoint
+{
+    // Settable per test (tests share one instance via the IClassFixture-scoped DI container) — reassign
+    // at the start of every [Fact] rather than relying on any default carried over from a prior test.
+    public Func<CancellationToken, Task> OnPublish { get; set; } = _ => Task.CompletedTask;
+
+    public Task Publish(object message, Type messageType, CancellationToken cancellationToken = default)
+        => OnPublish(cancellationToken);
+
+    public Task Publish<T>(T message, CancellationToken cancellationToken = default) where T : class
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish<T>(T message, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken = default)
+        where T : class
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish<T>(T message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default)
+        where T : class
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish(object message, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish(object message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish(object message, Type messageType, IPipe<PublishContext> publishPipe,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish<T>(object values, CancellationToken cancellationToken = default) where T : class
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish<T>(object values, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken = default)
+        where T : class
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public Task Publish<T>(object values, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default)
+        where T : class
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+
+    public ConnectHandle ConnectPublishObserver(IPublishObserver observer)
+        => throw new NotSupportedException("Unused by OutboxProcessor.");
+}

--- a/src/Modules/Outbox/Outbox.Tests/OutboxProcessorTestFactory.cs
+++ b/src/Modules/Outbox/Outbox.Tests/OutboxProcessorTestFactory.cs
@@ -1,0 +1,27 @@
+using Common.Tests;
+using MassTransit;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Outbox.Tests;
+
+// Real Postgres (via the base IntegrationTestFactory Testcontainer), fake bus. OutboxOptions:IsProcessor
+// stays false (the base default), so OutboxProcessor is never auto-registered as a BackgroundService —
+// tests call ProcessBatchAsync directly instead, for deterministic single-batch runs with no RabbitMQ
+// broker and no poll-timer races.
+public class OutboxProcessorTestFactory : IntegrationTestFactory
+{
+    protected override string[] GetActiveModules() => ["Outbox"];
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddSingleton<FakePublishEndpoint>();
+            services.AddSingleton<IPublishEndpoint>(sp => sp.GetRequiredService<FakePublishEndpoint>());
+        });
+    }
+}

--- a/src/Modules/Outbox/Outbox.Tests/OutboxProcessorTests.cs
+++ b/src/Modules/Outbox/Outbox.Tests/OutboxProcessorTests.cs
@@ -1,0 +1,192 @@
+using Common.Application.Options;
+using Common.Application.Persistence.Outbox;
+using Common.Domain.StronglyTypedIds;
+using Common.IntegrationEvents;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Outbox.Persistence;
+using Xunit;
+
+#pragma warning disable CA1707
+
+namespace Outbox.Tests;
+
+// Calls OutboxProcessor.ProcessBatchAsync directly (internal, via InternalsVisibleTo) instead of going
+// through the BackgroundService's poll-interval timer — deterministic, no timing races. IsProcessor stays
+// false (base IntegrationTestFactory default) so no auto-polling instance runs concurrently underneath.
+public sealed class OutboxProcessorTests : IClassFixture<OutboxProcessorTestFactory>
+{
+    private readonly OutboxProcessorTestFactory _factory;
+    private readonly FakePublishEndpoint _fakePublishEndpoint;
+
+    public OutboxProcessorTests(OutboxProcessorTestFactory factory)
+    {
+        _factory = factory;
+        _ = factory.CreateClient(); // eager — IClassFixture rule
+        _fakePublishEndpoint = factory.Services.GetRequiredService<FakePublishEndpoint>();
+        _fakePublishEndpoint.OnPublish = _ => Task.CompletedTask; // reset before every test
+    }
+
+    private static OutboxOptions BuildOptions(int batchSize = 10, int maxRetryCount = 3) => new()
+    {
+        PollIntervalMs = 100_000, // never consulted — ProcessBatchAsync is called directly, not via the loop
+        BatchSize = batchSize,
+        MaxRetryCount = maxRetryCount,
+        IsProcessor = false,
+        BaseBackoffSeconds = 1,
+        MaxBackoffSeconds = 2,
+        PublishTimeoutMs = 2000,
+        ClaimLeaseSeconds = 120,
+        LagThresholdMinutes = 5,
+        MetricsCronSchedule = "*/5 * * * *"
+    };
+
+    private OutboxProcessor CreateProcessor(OutboxOptions options) => new(
+        _factory.Services.GetRequiredService<IServiceScopeFactory>(),
+        Options.Create(options),
+        _factory.Services.GetRequiredService<TimeProvider>(),
+        _factory.Services.GetRequiredService<ILogger<OutboxProcessor>>());
+
+    private async Task<int> SeedMessageAsync(DateTimeOffset createdOn, string phoneSuffix, Action<OutboxMessage>? configure = null)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<OutboxDbContext>();
+        var message = OutboxMessage.Create(createdOn, new UserRegisteredIntegrationEvent(
+            ApplicationUserId.New(), "Test User", $"+90555{phoneSuffix}"));
+        configure?.Invoke(message);
+        db.OutboxMessages.Add(message);
+        await db.SaveChangesAsync();
+        return message.Id;
+    }
+
+    private async Task<OutboxMessage> GetMessageAsync(int id)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<OutboxDbContext>();
+        return await db.OutboxMessages.AsNoTracking().SingleAsync(m => m.Id == id);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_PublishSucceeds_MarksProcessed()
+    {
+        var messageId = await SeedMessageAsync(DateTimeOffset.UtcNow, "0001001");
+
+        using var processor = CreateProcessor(BuildOptions());
+        var processed = await processor.ProcessBatchAsync(CancellationToken.None);
+        var message = await GetMessageAsync(messageId);
+
+        Assert.True(processed >= 1);
+        Assert.True(message.IsProcessed);
+        Assert.NotNull(message.ProcessedOn);
+        Assert.Null(message.FailedOn);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_PublishFails_SchedulesRetryWithLease()
+    {
+        _fakePublishEndpoint.OnPublish = _ => throw new InvalidOperationException("simulated broker failure");
+
+        var messageId = await SeedMessageAsync(DateTimeOffset.UtcNow, "0001002");
+
+        using var processor = CreateProcessor(BuildOptions(maxRetryCount: 3));
+        await processor.ProcessBatchAsync(CancellationToken.None);
+        var message = await GetMessageAsync(messageId);
+
+        Assert.Equal(1, message.RetryCount);
+        Assert.NotNull(message.NextRetryAt);
+        Assert.True(message.NextRetryAt > DateTimeOffset.UtcNow);
+        Assert.False(message.IsProcessed);
+        Assert.Null(message.FailedOn);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_RetriesExhausted_MarksFailed()
+    {
+        _fakePublishEndpoint.OnPublish = _ => throw new InvalidOperationException("simulated broker failure");
+
+        const int maxRetryCount = 3;
+        var messageId = await SeedMessageAsync(DateTimeOffset.UtcNow, "0001003", message =>
+        {
+            for (var i = 0; i < maxRetryCount - 1; i++)
+            {
+                message.IncrementRetryCount(DateTimeOffset.UtcNow, TimeSpan.Zero);
+            }
+
+            message.ReleaseClaim(); // make immediately eligible — IncrementRetryCount left NextRetryAt set
+        });
+
+        using var processor = CreateProcessor(BuildOptions(maxRetryCount: maxRetryCount));
+        await processor.ProcessBatchAsync(CancellationToken.None);
+        var message = await GetMessageAsync(messageId);
+
+        Assert.Equal(maxRetryCount, message.RetryCount);
+        Assert.NotNull(message.FailedOn);
+        Assert.False(message.IsProcessed);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_ThreeConsecutiveFailures_ReleasesUnattemptedClaims()
+    {
+        _fakePublishEndpoint.OnPublish = _ => throw new InvalidOperationException("simulated broker failure");
+
+        var now = DateTimeOffset.UtcNow;
+        var ids = new List<int>();
+        for (var i = 0; i < 5; i++)
+        {
+            ids.Add(await SeedMessageAsync(now.AddMilliseconds(i), $"000200{i}"));
+        }
+
+        using var processor = CreateProcessor(BuildOptions(batchSize: 10, maxRetryCount: 5));
+        await processor.ProcessBatchAsync(CancellationToken.None);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var attempted = await GetMessageAsync(ids[i]);
+            Assert.Equal(1, attempted.RetryCount);
+            Assert.NotNull(attempted.NextRetryAt);
+            Assert.True(attempted.NextRetryAt > DateTimeOffset.UtcNow);
+        }
+
+        for (var i = 3; i < 5; i++)
+        {
+            var released = await GetMessageAsync(ids[i]);
+            Assert.Equal(0, released.RetryCount);
+            Assert.Null(released.NextRetryAt);
+        }
+    }
+
+    [Fact]
+    public async Task ProcessBatch_ConcurrentRuns_EachMessagePublishedOnce()
+    {
+        var publishCount = 0;
+        _fakePublishEndpoint.OnPublish = _ =>
+        {
+            Interlocked.Increment(ref publishCount);
+            return Task.CompletedTask;
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        var ids = new List<int>();
+        for (var i = 0; i < 20; i++)
+        {
+            ids.Add(await SeedMessageAsync(now.AddMilliseconds(i), $"00030{i:D2}"));
+        }
+
+        // BatchSize (12) < total messages (20): neither single ProcessBatchAsync call can claim everything
+        // alone, so the two concurrent calls are forced to split the 20 rows between them. FOR UPDATE
+        // SKIP LOCKED guarantees the split has no overlap — this is what's under test.
+        using var processor = CreateProcessor(BuildOptions(batchSize: 12));
+        await Task.WhenAll(
+            processor.ProcessBatchAsync(CancellationToken.None),
+            processor.ProcessBatchAsync(CancellationToken.None));
+
+        Assert.Equal(20, publishCount);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<OutboxDbContext>();
+        var processedCount = await db.OutboxMessages.AsNoTracking().CountAsync(m => ids.Contains(m.Id) && m.IsProcessed);
+        Assert.Equal(20, processedCount);
+    }
+}

--- a/src/Modules/Outbox/Outbox/Outbox.csproj
+++ b/src/Modules/Outbox/Outbox/Outbox.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Outbox.Tests"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Update="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Modules/Outbox/Outbox/OutboxProcessor.cs
+++ b/src/Modules/Outbox/Outbox/OutboxProcessor.cs
@@ -33,13 +33,23 @@ public sealed partial class OutboxProcessor(
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            await ProcessBatchAsync(stoppingToken);
+            var processed = await ProcessBatchAsync(stoppingToken);
+
+            // Drain fast when the queue is backed up: a full batch means more work is likely waiting,
+            // so poll again immediately instead of idling out PollIntervalMs.
+            if (processed >= options.Value.BatchSize)
+            {
+                continue;
+            }
+
             await Task.Delay(options.Value.PollIntervalMs, stoppingToken)
                 .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
         }
     }
 
-    private async Task ProcessBatchAsync(CancellationToken ct)
+    // internal (not private): unit-tested directly from Outbox.Tests via InternalsVisibleTo, calling
+    // ProcessBatchAsync once per test instead of racing the BackgroundService's poll-interval timer.
+    internal async Task<int> ProcessBatchAsync(CancellationToken ct)
     {
         using var scope = scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OutboxDbContext>();
@@ -48,29 +58,60 @@ public sealed partial class OutboxProcessor(
         var opts = options.Value;
         var sw = Stopwatch.StartNew();
 
-        await using var tx = await db.Database.BeginTransactionAsync(ct);
         try
         {
+            // Lease-claim pattern: this single atomic UPDATE ... RETURNING claims up to BatchSize rows by
+            // pushing NextRetryAt into the future (the "lease") and returns them — no explicit transaction,
+            // autocommit, so the FOR UPDATE SKIP LOCKED row locks release the instant this statement
+            // commits. Publishing to RabbitMQ then happens with NO open transaction and NO held locks, so a
+            // slow/down broker can no longer starve the connection pool. A crash between claiming and
+            // publishing leaves the message leased-but-unpublished; once the lease (ClaimLeaseSeconds)
+            // expires it's picked up again by any instance. That can produce duplicate publishes — this is
+            // acceptable and by design, because all consumers inherit IntegrationEventHandlerBase (idempotent).
 #pragma warning disable S2077 // SQL queries should not be vulnerable to injection attacks — parameters are safe
             var messages = await db.OutboxMessages
                 .FromSqlRaw(
                     """
-                    SELECT * FROM "Outbox"."OutboxMessages"
-                    WHERE "IsProcessed" = false
-                      AND "FailedOn" IS NULL
-                      AND ("NextRetryAt" IS NULL OR "NextRetryAt" <= (NOW() AT TIME ZONE 'UTC'))
-                    ORDER BY "CreatedOn"
-                    LIMIT {0}
-                    FOR UPDATE SKIP LOCKED
+                    UPDATE "Outbox"."OutboxMessages" o
+                    SET "NextRetryAt" = (NOW() AT TIME ZONE 'UTC') + make_interval(secs => {1})
+                    FROM (
+                        SELECT "Id" FROM "Outbox"."OutboxMessages"
+                        WHERE "IsProcessed" = false
+                          AND "FailedOn" IS NULL
+                          AND ("NextRetryAt" IS NULL OR "NextRetryAt" <= (NOW() AT TIME ZONE 'UTC'))
+                        ORDER BY "CreatedOn"
+                        LIMIT {0}
+                        FOR UPDATE SKIP LOCKED
+                    ) c
+                    WHERE o."Id" = c."Id"
+                    RETURNING o.*
                     """,
-                    opts.BatchSize)
+                    opts.BatchSize,
+                    opts.ClaimLeaseSeconds)
                 .ToListAsync(ct);
 #pragma warning restore S2077
 
             OutboxTelemetry.PollBatchSize.Record(messages.Count);
 
-            foreach (var message in messages)
+            var consecutiveFailures = 0;
+
+            for (var i = 0; i < messages.Count; i++)
             {
+                var message = messages[i];
+
+                // Three publishes in a row have failed — the broker is very likely down. Stop attempting
+                // the rest of this batch and release their claims immediately so they don't sit idle for
+                // the full lease before becoming eligible again.
+                if (consecutiveFailures >= 3)
+                {
+                    for (var j = i; j < messages.Count; j++)
+                    {
+                        messages[j].ReleaseClaim();
+                    }
+
+                    break;
+                }
+
                 Activity? activity;
                 if (message.TraceId is not null && message.ParentSpanId is not null)
                 {
@@ -108,20 +149,33 @@ public sealed partial class OutboxProcessor(
                         continue;
                     }
 
-                    await publishEndpoint.Publish(integrationEvent, integrationEvent.GetType(), ct);
+                    using var publishCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    publishCts.CancelAfter(opts.PublishTimeoutMs);
+                    await publishEndpoint.Publish(integrationEvent, integrationEvent.GetType(), publishCts.Token);
                     message.MarkAsProcessed(timeProvider.GetUtcNow());
                     OutboxTelemetry.MessagesPublished.Add(1);
                     activity?.SetStatus(ActivityStatusCode.Ok);
                     LogPublished(logger, message.Id, integrationEvent.GetType().Name);
+                    consecutiveFailures = 0;
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Real shutdown (not just this message's PublishTimeoutMs) — propagate, don't treat
+                    // it as a publish failure.
+                    throw;
                 }
 #pragma warning disable CA1031
                 catch (Exception ex)
 #pragma warning restore CA1031
                 {
+                    // Either a genuine publish failure or the per-publish PublishTimeoutMs firing
+                    // (OperationCanceledException with ct still live) — both go through the same
+                    // retry/backoff path.
                     activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                     activity?.SetTag("exception.message", ex.Message);
                     activity?.SetTag("exception.type", ex.GetType().Name);
                     message.IncrementRetryCount(timeProvider.GetUtcNow(), ComputeBackoff(message.RetryCount, opts));
+                    consecutiveFailures++;
                     if (message.RetryCount >= opts.MaxRetryCount)
                     {
                         message.MarkAsFailed(timeProvider.GetUtcNow());
@@ -136,15 +190,15 @@ public sealed partial class OutboxProcessor(
             }
 
             await db.SaveChangesAsync(ct);
-            await tx.CommitAsync(ct);
             OutboxTelemetry.ProcessingDuration.Record(sw.Elapsed.TotalMilliseconds);
+            return messages.Count;
         }
 #pragma warning disable CA1031
         catch (Exception ex) when (!ct.IsCancellationRequested)
 #pragma warning restore CA1031
         {
-            await tx.RollbackAsync(CancellationToken.None);
             LogBatchError(logger, ex);
+            return 0;
         }
     }
 

--- a/src/Modules/Outbox/Outbox/OutboxProcessor.cs
+++ b/src/Modules/Outbox/Outbox/OutboxProcessor.cs
@@ -94,6 +94,7 @@ public sealed partial class OutboxProcessor(
             OutboxTelemetry.PollBatchSize.Record(messages.Count);
 
             var consecutiveFailures = 0;
+            var aborted = false;
 
             for (var i = 0; i < messages.Count; i++)
             {
@@ -109,6 +110,7 @@ public sealed partial class OutboxProcessor(
                         messages[j].ReleaseClaim();
                     }
 
+                    aborted = true;
                     break;
                 }
 
@@ -191,7 +193,11 @@ public sealed partial class OutboxProcessor(
 
             await db.SaveChangesAsync(ct);
             OutboxTelemetry.ProcessingDuration.Record(sw.Elapsed.TotalMilliseconds);
-            return messages.Count;
+
+            // On abort the released rows are immediately eligible again — report 0 so ExecuteAsync
+            // waits out PollIntervalMs instead of drain-fast re-claiming them in a tight loop
+            // against a broker that is almost certainly still down.
+            return aborted ? 0 : messages.Count;
         }
 #pragma warning disable CA1031
         catch (Exception ex) when (!ct.IsCancellationRequested)

--- a/src/Modules/Products/Products.Infrastructure/Persistence/Migrations/20260719143914_AuditLogCreatedOnIndex.Designer.cs
+++ b/src/Modules/Products/Products.Infrastructure/Persistence/Migrations/20260719143914_AuditLogCreatedOnIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using Products.Infrastructure.Persistence;
 namespace Products.Infrastructure.Migrations
 {
     [DbContext(typeof(ProductsDbContext))]
-    partial class ProductsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719143914_AuditLogCreatedOnIndex")]
+    partial class AuditLogCreatedOnIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Products/Products.Infrastructure/Persistence/Migrations/20260719143914_AuditLogCreatedOnIndex.cs
+++ b/src/Modules/Products/Products.Infrastructure/Persistence/Migrations/20260719143914_AuditLogCreatedOnIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Products.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AuditLogCreatedOnIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLog_CreatedOn",
+                schema: "Products",
+                table: "AuditLog",
+                column: "CreatedOn");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLog_CreatedOn",
+                schema: "Products",
+                table: "AuditLog");
+        }
+    }
+}

--- a/src/Modules/Products/Products.Tests/Persistence/BaseDbContextAtomicityTests.cs
+++ b/src/Modules/Products/Products.Tests/Persistence/BaseDbContextAtomicityTests.cs
@@ -155,4 +155,70 @@ public class BaseDbContextAtomicityTests : BaseIntegrationTest
         // Store.Create = 1 event, Update with name + description = 2 events = total 3
         Assert.Equal(3, auditLogEntries.Count);
     }
+
+    [Fact]
+    public async Task SaveChanges_FirstAttemptFails_RetryPersistsAuditAndOutbox()
+    {
+        // Arrange - storeA and storeB share the same OwnerId, which violates the unique index on Stores.OwnerId
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ProductsDbContext>();
+        var outboxDb = scope.ServiceProvider.GetRequiredService<OutboxDbContext>();
+        var ownerId = new ApplicationUserId(Guid.NewGuid());
+
+        var storeA = Store.Create(ownerId, _faker.Company.CompanyName(), _faker.Lorem.Sentence(), _faker.Address.FullAddress());
+        var storeB = Store.Create(ownerId, _faker.Company.CompanyName(), _faker.Lorem.Sentence(), _faker.Address.FullAddress());
+
+        var outboxCountBefore = await outboxDb.OutboxMessages.AsNoTracking().CountAsync();
+
+        db.Stores.Add(storeA);
+        db.Stores.Add(storeB);
+
+        // Act - first attempt fails on the unique constraint violation
+        await Assert.ThrowsAnyAsync<Exception>(() => db.SaveChangesAsync());
+
+        // Fix the conflicting change in the SAME scope/context, as a client retry would
+        db.Entry(storeB).State = EntityState.Detached;
+
+        // Act - retry SaveChangesAsync on the SAME context instance
+        await db.SaveChangesAsync();
+
+        // Assert - storeA was persisted
+        var persistedStore = await db.Stores.AsNoTracking().SingleOrDefaultAsync(s => s.Id == storeA.Id);
+        Assert.NotNull(persistedStore);
+
+        // Assert - exactly one AuditLog row for storeA's event, zero for the never-persisted storeB
+        var storeAAuditEntries = await db.AuditLog
+            .AsNoTracking()
+            .Where(e => e.AggregateId == storeA.Id.Value)
+            .ToListAsync();
+        Assert.Single(storeAAuditEntries);
+
+        var storeBAuditEntries = await db.AuditLog
+            .AsNoTracking()
+            .Where(e => e.AggregateId == storeB.Id.Value)
+            .ToListAsync();
+        Assert.Empty(storeBAuditEntries);
+
+        // Assert - exactly one new OutboxMessage row for storeA's event
+        var outboxCountAfter = await outboxDb.OutboxMessages.AsNoTracking().CountAsync();
+        Assert.Equal(outboxCountBefore + 1, outboxCountAfter);
+    }
+
+    [Fact]
+    public async Task SaveChanges_Success_ClearsAggregateEvents()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ProductsDbContext>();
+        var ownerId = new ApplicationUserId(Guid.NewGuid());
+        var store = Store.Create(ownerId, _faker.Company.CompanyName(), _faker.Lorem.Sentence(), _faker.Address.FullAddress());
+
+        db.Stores.Add(store);
+
+        // Act
+        await db.SaveChangesAsync();
+
+        // Assert
+        Assert.Empty(store.Events);
+    }
 }


### PR DESCRIPTION
## Summary
Clears all 12 tasks in `TODO-load-hardening.md` (full-codebase audit for pool starvation, transaction leaks, memory growth, races, and resiliency gaps). Each task was implemented by an isolated agent in its own worktree/branch, then merged here; task order/dependencies (Task 10 before 11, same file) preserved.

- fix(outbox): stop publishing to RabbitMQ inside an open DB transaction (lease-claim pattern)
- fix(common): fail fast when Production runs without Redis (cache + SignalR backplane)
- fix(notifications): atomic OTP verify to close brute-force and double-use races
- fix(host): add exponential consumer retry policy to MassTransit RabbitMQ transport
- fix(iam): config-driven captcha provider with Production guard against Dummy
- fix(iam): dispose HttpResponseMessage in ReCaptchaService.ValidateAsync
- fix(common): batch AuditLog purge deletes and index CreatedOn (+ 2 EF migrations)
- fix(common): bound consumer idempotency L1 cache to 1h, keep 24h in L2
- fix(common): add explicit 10s timeout to inter-module request client
- fix(common): survive OutboxSaveHelper save failures without losing events
- fix(iam): wrap SelfRegister user+role+session in one transaction
- fix(common): raise FusionCache FactoryHardTimeout from 1.5s to 30s
- fix(notifications): reuse shared Redis multiplexer for SignalR backplane
- fix(common): loosen Register rate-limit policy in IntegrationTestFactory for tests (integration-only fix, needed once all 12 branches were merged together — see below)

## Notes for review
- **Task 3 (OTP atomic verify)**: NOT dormant — `Otp/Setup.cs` registers `RedisOtpService` (real random OTPs, atomic Lua verify) whenever `CachingOptions:UseRedis=true`; only the `UseRedis=false` fallback keeps `DummyOtpService` (real `OtpService` was already commented out pre-existing this PR). Because `ISmsGateway` is still the no-op `DummySmsGateway`, a Production startup guard now throws until a real SMS gateway exists (see review fixes below).
- **Task 7 (AuditLog)**: generated EF migrations for IAM and Products only (`AuditLogCreatedOnIndex`); Outbox has no AuditLog table so its migration was correctly discarded.
- **Rate-limit fix**: every `CustomRateLimitingOptions` policy except `Register` was already loosened for tests in `IntegrationTestFactory.cs`. Task 11 added a 6th test hitting `/users/register/self`, tripping the real 5-per-60s production limit. Added the same test-only override the other policies already have — no production behavior change.

## Review fixes (post-review commits)
- **Environment detection**: all registration-time Production guards (caching, SignalR backplane, captcha, SMS) now resolve the environment from the host-registered `IHostEnvironment` descriptor (`IsProductionEnvironment()` extension) instead of reading raw `ASPNETCORE_ENVIRONMENT` — honors `DOTNET_ENVIRONMENT`/`UseEnvironment` too, and guard tests inject a `FakeHostEnvironment` instead of mutating the process-wide env var (which raced parallel factory boots).
- **fix(notifications)**: Production startup guard against the no-op `DummySmsGateway` — with Redis on, `RedisOtpService` generates real OTPs that would never reach users.
- **fix(notifications)**: `RedisOtpService.StoreAsync` is now a single atomic Lua EVAL (HSET + PEXPIRE) — no window where an OTP key exists without a TTL.
- **fix(outbox)**: consecutive-failure abort now returns 0 so `ExecuteAsync` waits out `PollIntervalMs` instead of drain-fast re-claiming the released rows in a tight loop against a down broker.
- **test(outbox)**: `Outbox.Tests` runs sequentially (`CollectionBehavior(DisableTestParallelization = true)`) — two `WebApplicationFactory` fixtures in one assembly must not boot in parallel (CLAUDE.md §8).

## Test plan
- [x] `make build` — 0 warnings, 0 errors
- [x] `make test-common` — 78/78
- [x] `make test-host` — 15/15
- [x] `make test-iam` — 72/72
- [x] `make test-products` — 101/101
- [x] `make test-notifications` — 27/27 (2 new SMS-guard tests)
- [x] `make test-outbox` — 7/7
- [x] `make test-backgroundjobs` — 5/5
- [x] `/audit-architecture` — clean (no cross-module refs, no controllers, no raw `IPublishEndpoint` outside `OutboxProcessor`, no AutoMapper, config-driven module loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
